### PR TITLE
Add propellant line and line state value objects

### DIFF
--- a/docs/api/models/feed_systems.md
+++ b/docs/api/models/feed_systems.md
@@ -10,6 +10,7 @@ organised around three concerns:
 | Cycle implementations | [`feed_systems.cycles`](feed_systems/cycles.md) | One module per cycle topology (pressure-fed today; electric-pump, gas-generator, expander, staged-combustion to follow). |
 | Shared component descriptions | [`feed_systems.components`](feed_systems/components.md) | Static descriptions of pumps, turbines, gas generators, regenerative jackets, plus a tabulated-curve helper that cycle implementations consume. |
 | Tank thermodynamics | [`feed_systems.tank`](feed_systems/tank.md) | Two-phase tank model backed by CoolProp. |
+| Propellant lines | `feed_systems.lines` | The [`PropellantLine`][machwave.models.feed_systems.lines.PropellantLine] a feed system delivers — its name, its role, and the tank it draws from — and the [`LineState`][machwave.models.feed_systems.lines.LineState] the integrator carries for it. |
 
 ## The `FeedSystem` contract
 

--- a/machwave/models/feed_systems/__init__.py
+++ b/machwave/models/feed_systems/__init__.py
@@ -3,9 +3,12 @@ from machwave.models.feed_systems.base import FeedSystem
 from machwave.models.feed_systems.cycles.stacked_tank_pressure_fed import (
     StackedTankPressureFedFeedSystem,
 )
+from machwave.models.feed_systems.lines import LineState, PropellantLine
 
 __all__ = [
     "FeedSystem",
+    "LineState",
+    "PropellantLine",
     "StackedTankPressureFedFeedSystem",
     "components",
 ]

--- a/machwave/models/feed_systems/lines.py
+++ b/machwave/models/feed_systems/lines.py
@@ -1,0 +1,59 @@
+"""Propellant lines and the state the integrator carries for each of them."""
+
+import dataclasses
+
+import machwave.models.feed_systems.tank as tank_models
+import machwave.models.propellants.components as propellant_components
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class LineState:
+    """
+    The propellant a line still holds at one point in the integration.
+
+    Attributes:
+        fluid_mass: Mass of fluid left in the tank [kg].
+        internal_energy: Internal energy of that fluid [J]. None for an
+            isothermal tank, which runs no energy balance.
+    """
+
+    fluid_mass: float
+    internal_energy: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.fluid_mass < 0.0:
+            raise ValueError(f"fluid_mass must be non-negative, got {self.fluid_mass}")
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True, slots=True)
+class PropellantLine:
+    """
+    One propellant on its way from a tank to the injector.
+
+    Attributes:
+        name: Line name, which keys the line across the feed system, the
+            injector and the simulation state.
+        role: Whether the line carries an oxidizer, a fuel, or an additive such
+            as a triliquid diluent or a coolant.
+        tank: Tank the line draws from.
+    """
+
+    name: str
+    role: propellant_components.ComponentRole
+    tank: tank_models.Tank
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("name must be a non-empty string")
+
+        object.__setattr__(self, "role", propellant_components.ComponentRole(self.role))
+
+    @property
+    def initial_state(self) -> LineState:
+        """The line state the integrator starts from, as the tank was loaded."""
+        return LineState(
+            fluid_mass=self.tank.initial_fluid_mass,
+            internal_energy=(
+                None if self.tank.isothermal else self.tank.initial_internal_energy
+            ),
+        )

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -6,6 +6,7 @@ layer.
 
 from tests.factories.common import FluidStateFactory
 from tests.factories.feed_systems import (
+    PropellantLineFactory,
     StackedTankPressureFedFeedSystemFactory,
     TankFactory,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "MultiPortGrainSegmentFactory",
     "NozzleFactory",
     "OxidizerComponentFactory",
+    "PropellantLineFactory",
     "RodAndTubeGrainSegmentFactory",
     "SolidMotorFactory",
     "SolidMotorThrustChamberFactory",

--- a/tests/factories/feed_systems.py
+++ b/tests/factories/feed_systems.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import machwave.models.feed_systems as feed_systems_models
 import machwave.models.feed_systems.tank as tank_models
+import machwave.models.propellants as propellants_models
 
 
 class TankFactory:
@@ -17,6 +18,19 @@ class TankFactory:
         )
         kwargs.update(overrides)
         return tank_models.Tank(**kwargs)
+
+
+class PropellantLineFactory:
+    @classmethod
+    def build(cls, **overrides: Any) -> feed_systems_models.PropellantLine:
+        tank = overrides.pop("tank", None) or TankFactory.build()
+        kwargs: dict[str, Any] = dict(
+            name="oxidizer",
+            role=propellants_models.ComponentRole.OXIDIZER,
+            tank=tank,
+        )
+        kwargs.update(overrides)
+        return feed_systems_models.PropellantLine(**kwargs)
 
 
 class StackedTankPressureFedFeedSystemFactory:

--- a/tests/test_models/test_propulsion/test_feed_systems/test_lines.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_lines.py
@@ -1,0 +1,77 @@
+import dataclasses
+
+import pytest
+
+import machwave.models.feed_systems.lines as line_models
+import machwave.models.propellants as propellants_models
+from tests.factories import PropellantLineFactory, TankFactory
+
+
+class TestPropellantLine:
+    def test_carries_a_name_a_role_and_a_tank(self):
+        tank = TankFactory.build()
+        line = PropellantLineFactory.build(name="oxidizer", tank=tank)
+
+        assert line.name == "oxidizer"
+        assert line.role is propellants_models.ComponentRole.OXIDIZER
+        assert line.tank is tank
+
+    def test_coerces_the_role_from_its_value(self):
+        line = PropellantLineFactory.build(role="fuel")
+
+        assert line.role is propellants_models.ComponentRole.FUEL
+
+    def test_an_additive_line_is_a_valid_role(self):
+        line = PropellantLineFactory.build(name="diluent", role="additive")
+
+        assert line.role is propellants_models.ComponentRole.ADDITIVE
+
+    def test_rejects_an_empty_name(self):
+        with pytest.raises(ValueError, match="name"):
+            PropellantLineFactory.build(name="")
+
+    def test_rejects_an_unknown_role(self):
+        with pytest.raises(ValueError, match="pressurant"):
+            PropellantLineFactory.build(role="pressurant")
+
+    def test_is_frozen(self):
+        line = PropellantLineFactory.build()
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            line.name = "fuel"
+
+
+class TestPropellantLineInitialState:
+    def test_starts_at_the_tank_loading(self):
+        tank = TankFactory.build(initial_fluid_mass=4.0)
+        line = PropellantLineFactory.build(tank=tank)
+
+        assert line.initial_state.fluid_mass == pytest.approx(4.0)
+
+    def test_an_isothermal_tank_carries_no_internal_energy(self):
+        line = PropellantLineFactory.build(tank=TankFactory.build(isothermal=True))
+
+        assert line.initial_state.internal_energy is None
+
+    def test_a_tank_running_an_energy_balance_starts_at_its_loaded_energy(self):
+        tank = TankFactory.build(isothermal=False)
+        line = PropellantLineFactory.build(tank=tank)
+
+        assert line.initial_state.internal_energy == pytest.approx(
+            tank.initial_internal_energy
+        )
+
+
+class TestLineState:
+    def test_defaults_to_no_internal_energy(self):
+        state = line_models.LineState(fluid_mass=1.0)
+
+        assert state.fluid_mass == pytest.approx(1.0)
+        assert state.internal_energy is None
+
+    def test_an_empty_line_is_a_valid_state(self):
+        assert line_models.LineState(fluid_mass=0.0).fluid_mass == 0.0
+
+    def test_rejects_a_negative_fluid_mass(self):
+        with pytest.raises(ValueError, match="fluid_mass"):
+            line_models.LineState(fluid_mass=-1.0)


### PR DESCRIPTION
Closes #492.

The feed system identifies its propellants by the attribute names `fuel_tank` and `oxidizer_tank`, which leaves no room for a third propellant, a single propellant, or an oxidizer-only hybrid feed.

Adds `PropellantLine` (name, role, tank) and `LineState` (fluid mass, internal energy), plus `PropellantLine.initial_state` for the state the integrator starts from. The role reuses `ComponentRole`, whose `ADDITIVE` member covers a triliquid diluent or a coolant line. Pure addition; nothing consumes these yet.