### PR TITLE
Key the feed system by propellant line and solve every inlet state in one call

### DIFF
--- a/docs/api/models/feed_systems.md
+++ b/docs/api/models/feed_systems.md
@@ -1,6 +1,6 @@
 # models.feed_systems
 
-Feed-system models for biliquid rocket engines. The package describes how
+Feed-system models for liquid-fed rocket engines. The package describes how
 propellant is delivered from the tanks to the combustion chamber, and is
 organised around three concerns:
 
@@ -14,21 +14,23 @@ organised around three concerns:
 
 ## The `FeedSystem` contract
 
-Every cycle implementation extends [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] and supplies the pressure it delivers to each side of the injector:
+A feed system delivers one [`PropellantLine`][machwave.models.feed_systems.lines.PropellantLine] per propellant, keyed by line name, and every cycle implementation extends [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] to supply the pressure that reaches the injector on every line:
 
-- `get_oxidizer_tank_pressure(*, oxidizer_mass) -> float`
-- `get_fuel_tank_pressure(*, oxidizer_mass, fuel_mass) -> float`
+- `get_inlet_pressures(line_states) -> dict[str, float]`
 
-From those, the base class assembles the state each side of the injector is fed with:
+From those, the base class assembles the state every line is fed with:
 
-- `get_oxidizer_inlet_state(*, oxidizer_mass) -> FluidState`
-- `get_fuel_inlet_state(*, oxidizer_mass, fuel_mass) -> FluidState`
+- `get_inlet_states(line_states) -> dict[str, FluidState]`
 
-The default inlet state is the tank fluid at the tank temperature and density, at the pressure that survives the path to the injector. A cycle that heats or pressurizes a propellant on the way — a regenerative jacket, a pump — overrides the inlet-state method to say so.
+Both take the [`LineState`][machwave.models.feed_systems.lines.LineState] of every line — the fluid mass and the internal energy the integrator carries beside it — keyed by line name. Solving all the lines in one call is what the physics asks for: a cycle couples its lines, as the stacked-tank piston ties the fuel pressure to the oxidizer ullage pressure.
 
-The feed system is responsible for everything upstream of the injector face (tank state, piston and feedline losses, pump discharge, jacket pickup); the injector owns the orifice physics (discharge coefficient, area, and the per-side `MassFlowModel` that selects between single-phase incompressible and homogeneous-equilibrium two-phase flow). A [`FluidState`][machwave.common.fluid_state.FluidState] is the whole of what passes between them, so neither package imports the other — both depend only on the shared value object.
+Keying by name is what makes the propellant count free. A biliquid engine feeds an oxidizer line and a fuel line; a triliquid adds a third with the `ADDITIVE` role for a diluent or a coolant; an oxidizer-only hybrid feed and a monoliquid are the one-line case of the same contract.
 
-[`machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep`][machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep] composes the two: it reads both inlet states once per integration step, then calls [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] with them at each chamber pressure the solver tries.
+The default inlet state is the tank fluid at the tank temperature and density, at the pressure that survives the path to the injector. A cycle that heats or pressurizes a propellant on the way — a regenerative jacket, a pump — overrides `get_inlet_states` to say so.
+
+The feed system is responsible for everything upstream of the injector face (tank state, piston and feedline losses, pump discharge, jacket pickup); the injector owns the orifice physics (discharge coefficient, area, and the per-line `MassFlowModel` that selects between single-phase incompressible and homogeneous-equilibrium two-phase flow). A [`FluidState`][machwave.common.fluid_state.FluidState] is the whole of what passes between them, so neither package imports the other — both depend only on the shared value object.
+
+[`machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep`][machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep] composes the two: it reads every inlet state once per integration step, then calls [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] with them at each chamber pressure the solver tries.
 
 ## Public surface
 

--- a/docs/api/models/feed_systems/cycles.md
+++ b/docs/api/models/feed_systems/cycles.md
@@ -22,32 +22,50 @@ Additional cycles are under active development as separate work items: electric-
                    /regenerative-jacket specs)
 ```
 
-The cycle reads tank state via the [`Tank`][machwave.models.feed_systems.tank.Tank] instances it was constructed with, and combines that state with any [component specs](components.md) it owns to say what reaches the injector face. The simulation step lives in [`BiliquidEngineState.run_timestep`][machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep], which calls `get_oxidizer_inlet_state` and `get_fuel_inlet_state` once per integration step and hands the results to the [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] at each chamber pressure the solver tries.
+The cycle reads tank state through the [`PropellantLine`][machwave.models.feed_systems.lines.PropellantLine] instances it was constructed with, and combines that state with any [component specs](components.md) it owns to say what reaches the injector face. The simulation step lives in [`BiliquidEngineState.run_timestep`][machwave.simulation.biliquid.states.BiliquidEngineState.run_timestep], which calls `get_inlet_states` once per integration step and hands the results to the [`BipropellantInjector`][machwave.models.thrust_chamber.injector.BipropellantInjector] at each chamber pressure the solver tries.
 
 ---
 
 ## `StackedTankPressureFedFeedSystem`
 
-A bipropellant pressure-fed engine in which the oxidizer and fuel tanks are arranged as a single vertical stack separated by a piston. The oxidizer tank pressure pressurises both propellants — directly for the oxidizer, and indirectly for the fuel through the piston. Pressure loss across the piston is captured by `piston_loss`.
+A pressure-fed engine whose propellant tanks are arranged as a single vertical stack separated by a piston. The tank at the top of the stack — `pressurizing_line` — pressurises every propellant: directly for its own line, and through the piston for every line below it. Pressure loss across the piston is captured by `piston_loss`, and each feedline takes what `line_losses` states for it.
 
 **Construction**
+
+The two-line case a biliquid engine runs on has a convenience constructor, which names the lines `"oxidizer"` and `"fuel"`:
 
 ```python
 from machwave.models.feed_systems import StackedTankPressureFedFeedSystem
 from machwave.models.feed_systems.tank import Tank
 
-feed_system = StackedTankPressureFedFeedSystem(
-    oxidizer_line_diameter=0.010,    # m
-    oxidizer_line_length=0.5,        # m
-    fuel_line_diameter=0.008,        # m
-    fuel_line_length=0.5,            # m
+feed_system = StackedTankPressureFedFeedSystem.from_oxidizer_and_fuel(
+    oxidizer_tank=Tank("N2O", volume=0.010, temperature=298.0, initial_fluid_mass=5.0),
     fuel_tank=Tank("Ethanol", volume=0.008, temperature=298.0, initial_fluid_mass=3.0),
-    oxidizer_tank=Tank("N2O",   volume=0.010, temperature=298.0, initial_fluid_mass=5.0),
-    piston_loss=0.0,                  # Pa
+    piston_loss=0.0,          # Pa
+    oxidizer_line_loss=2e5,   # Pa
+    fuel_line_loss=2e5,       # Pa
 )
 ```
 
-**Mass-flow model.** The feed system supplies the inlet state for each side and the injector does the orifice dispatch. Inlet pressure is the oxidizer tank pressure for the oxidizer branch and `oxidizer_tank_pressure - piston_loss` for the fuel branch; downstream pressure is `chamber_pressure`. The injector picks SPI or HEM per side from its [`MassFlowModel`][machwave.models.thrust_chamber.injector.MassFlowModel]:
+Any other propellant count is built from the lines themselves — here a triliquid with a diluent below the piston:
+
+```python
+from machwave.models.feed_systems import PropellantLine, StackedTankPressureFedFeedSystem
+from machwave.models.propellants import ComponentRole
+
+feed_system = StackedTankPressureFedFeedSystem(
+    lines=[
+        PropellantLine(name="oxidizer", role=ComponentRole.OXIDIZER, tank=oxidizer_tank),
+        PropellantLine(name="fuel", role=ComponentRole.FUEL, tank=fuel_tank),
+        PropellantLine(name="diluent", role=ComponentRole.ADDITIVE, tank=diluent_tank),
+    ],
+    pressurizing_line="oxidizer",
+    piston_loss=1e5,
+    line_losses={"oxidizer": 2e5, "fuel": 2e5, "diluent": 1e5},
+)
+```
+
+**Mass-flow model.** The feed system supplies the inlet state of every line and the injector does the orifice dispatch. Inlet pressure is the pressurizing tank pressure for its own line and that pressure less `piston_loss` for every line below the piston, each less its own feedline loss; downstream pressure is `chamber_pressure`. The injector picks SPI or HEM per line from its [`MassFlowModel`][machwave.models.thrust_chamber.injector.MassFlowModel]:
 
 - **SPI** (single-phase incompressible) — `get_mass_flow_orifice` in [`machwave.core.incompressible_flow`](../../core.md):
 
@@ -59,7 +77,7 @@ feed_system = StackedTankPressureFedFeedSystem(
 
 - **HEM** (homogeneous-equilibrium two-phase) — `get_homogeneous_equilibrium_mass_flux` in [`machwave.core.two_phase_flow`](../../core.md), required for self-pressurized propellants such as nitrous oxide where the upstream saturated liquid flashes across the orifice and the flow can choke on the two-phase sound speed. The injector multiplies the returned mass flux by $C_d \cdot A$.
 
-Line geometry (`oxidizer_line_diameter`, `oxidizer_line_length`, `fuel_line_diameter`, `fuel_line_length`) is currently stored on the instance for downstream issues that will add feedline pressure drop, but is not consumed by the mass-flow model itself yet.
+Feedline pressure drop is stated for the design flow through `line_losses` rather than computed from the flow and the line geometry.
 
 ---
 

--- a/examples/1kn_biliquid_engine.py
+++ b/examples/1kn_biliquid_engine.py
@@ -46,7 +46,7 @@ def main():
         OXIDIZER_NAME, volume=3.80e-3, temperature=300, initial_fluid_mass=2.78
     )
 
-    feed_system = feed_systems.StackedTankPressureFedFeedSystem(
+    feed_system = feed_systems.StackedTankPressureFedFeedSystem.from_oxidizer_and_fuel(
         oxidizer_tank=oxidizer_tank,
         fuel_tank=fuel_tank,
         piston_loss=1e5,

--- a/machwave/models/feed_systems/base.py
+++ b/machwave/models/feed_systems/base.py
@@ -1,126 +1,106 @@
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 
 import machwave.common.fluid_state as fluid_state_models
-import machwave.models.feed_systems.tank as tank
+import machwave.models.feed_systems.lines as line_models
+import machwave.models.propellants.components as propellant_components
 
 
 class FeedSystem(ABC):
-    """Abstract base class for a bipropellant feed system in a biliquid rocket engine."""
+    """
+    Abstract base class for the feed system of a rocket engine.
 
-    def __init__(self, fuel_tank: tank.Tank, oxidizer_tank: tank.Tank):
+    The system delivers one `PropellantLine` per propellant, keyed by line
+    name, and solves every line together: a cycle couples its lines
+    physically, as the stacked-tank piston ties the fuel pressure to the
+    oxidizer ullage pressure.
+    """
+
+    def __init__(self, lines: Sequence[line_models.PropellantLine]):
         """
-        Initialize the FeedSystem with associated tank objects.
+        Initialize the feed system with the lines it delivers.
 
         Args:
-            fuel_tank: Instance representing the fuel tank.
-            oxidizer_tank: Instance representing the oxidizer tank.
+            lines: Propellant lines the system feeds, one per propellant.
+
+        Raises:
+            ValueError: If no line was given, or if two lines share a name.
         """
-        self.fuel_tank = fuel_tank
-        self.oxidizer_tank = oxidizer_tank
+        self.lines: dict[str, line_models.PropellantLine] = {
+            line.name: line for line in lines
+        }
+
+        if not lines:
+            raise ValueError("lines must hold at least one propellant line")
+        if len(self.lines) != len(lines):
+            raise ValueError(
+                f"line names must be unique, got {[line.name for line in lines]}"
+            )
 
     def get_initial_propellant_mass(self) -> float:
         """Compute and return the initial propellant mass in the system [kg]."""
-        return self.fuel_tank.initial_fluid_mass + self.oxidizer_tank.initial_fluid_mass
+        return sum(line.tank.initial_fluid_mass for line in self.lines.values())
 
-    def get_oxidizer_inlet_state(
-        self,
-        *,
-        oxidizer_mass: float,
-        oxidizer_internal_energy: float | None = None,
-    ) -> fluid_state_models.FluidState:
-        """
-        Return the oxidizer state delivered to the injector inlet.
+    def get_lines_with_role(
+        self, role: propellant_components.ComponentRole
+    ) -> tuple[line_models.PropellantLine, ...]:
+        """Return every line carrying the given role, in the order they were given."""
+        return tuple(line for line in self.lines.values() if line.role == role)
 
-        Args:
-            oxidizer_mass: Current oxidizer mass in the tank [kg].
-            oxidizer_internal_energy: Current internal energy of the oxidizer
-                [J]. Required for a tank running an energy balance, unused
-                otherwise.
+    def get_inlet_states(
+        self, line_states: Mapping[str, line_models.LineState]
+    ) -> dict[str, fluid_state_models.FluidState]:
         """
-        return fluid_state_models.FluidState(
-            fluid_name=self.oxidizer_tank.fluid_name,
-            pressure=self.get_oxidizer_tank_pressure(
-                oxidizer_mass=oxidizer_mass,
-                oxidizer_internal_energy=oxidizer_internal_energy,
-            ),
-            temperature=self.oxidizer_tank.get_temperature(
-                oxidizer_mass, oxidizer_internal_energy
-            ),
-            density=self.oxidizer_tank.get_density(
-                oxidizer_mass, oxidizer_internal_energy
-            ),
-        )
+        Return the state delivered to the injector inlet on every line.
 
-    def get_fuel_inlet_state(
-        self,
-        *,
-        oxidizer_mass: float,
-        fuel_mass: float,
-        fuel_internal_energy: float | None = None,
-        oxidizer_internal_energy: float | None = None,
-    ) -> fluid_state_models.FluidState:
-        """
-        Return the fuel state delivered to the injector inlet.
+        Each state is the tank fluid at the tank temperature and density, at
+        the pressure that survives the path to the injector. A cycle that heats
+        or works on a propellant on the way — a regenerative jacket, a pump —
+        overrides this to say so.
 
         Args:
-            oxidizer_mass: Current oxidizer mass in the tank [kg]. Needed
-                because some feed systems pressurize the fuel from the oxidizer
-                side.
-            fuel_mass: Current fuel mass in the tank [kg].
-            fuel_internal_energy: Current internal energy of the fuel [J].
-                Required for a tank running an energy balance, unused
-                otherwise.
-            oxidizer_internal_energy: Current internal energy of the oxidizer
-                [J]. Required for a tank running an energy balance, unused
-                otherwise.
+            line_states: Fluid mass and internal energy of every line, keyed by
+                line name.
+
+        Returns:
+            Injector inlet state of every line, keyed by line name.
+
+        Raises:
+            ValueError: If any line of the system has no state.
         """
-        return fluid_state_models.FluidState(
-            fluid_name=self.fuel_tank.fluid_name,
-            pressure=self.get_fuel_tank_pressure(
-                oxidizer_mass=oxidizer_mass,
-                fuel_mass=fuel_mass,
-                fuel_internal_energy=fuel_internal_energy,
-                oxidizer_internal_energy=oxidizer_internal_energy,
-            ),
-            temperature=self.fuel_tank.get_temperature(fuel_mass, fuel_internal_energy),
-            density=self.fuel_tank.get_density(fuel_mass, fuel_internal_energy),
-        )
+        missing = [name for name in self.lines if name not in line_states]
+        if missing:
+            raise ValueError(f"no line state was given for {missing}")
+
+        inlet_pressures = self.get_inlet_pressures(line_states)
+
+        inlet_states = {}
+        for name, line in self.lines.items():
+            line_state = line_states[name]
+            inlet_states[name] = fluid_state_models.FluidState(
+                fluid_name=line.tank.fluid_name,
+                pressure=inlet_pressures[name],
+                temperature=line.tank.get_temperature(
+                    line_state.fluid_mass, line_state.internal_energy
+                ),
+                density=line.tank.get_density(
+                    line_state.fluid_mass, line_state.internal_energy
+                ),
+            )
+        return inlet_states
 
     @abstractmethod
-    def get_oxidizer_tank_pressure(
-        self, *, oxidizer_mass: float, oxidizer_internal_energy: float | None = None
-    ) -> float:
+    def get_inlet_pressures(
+        self, line_states: Mapping[str, line_models.LineState]
+    ) -> dict[str, float]:
         """
-        Compute and return the oxidizer pressure at the injector inlet [Pa].
+        Compute the pressure delivered to the injector inlet on every line [Pa].
 
         Args:
-            oxidizer_mass: Current oxidizer mass in the tank [kg].
-            oxidizer_internal_energy: Current internal energy of the oxidizer
-                [J]. Required for a tank running an energy balance, unused
-                otherwise.
-        """
-        pass
+            line_states: Fluid mass and internal energy of every line, keyed by
+                line name.
 
-    @abstractmethod
-    def get_fuel_tank_pressure(
-        self,
-        *,
-        oxidizer_mass: float,
-        fuel_mass: float,
-        fuel_internal_energy: float | None = None,
-        oxidizer_internal_energy: float | None = None,
-    ) -> float:
-        """
-        Compute and return the fuel pressure at the injector inlet [Pa].
-
-        Args:
-            oxidizer_mass: Current oxidizer mass in the tank [kg].
-            fuel_mass: Current fuel mass in the tank [kg].
-            fuel_internal_energy: Current internal energy of the fuel [J].
-                Required for a tank running an energy balance, unused
-                otherwise.
-            oxidizer_internal_energy: Current internal energy of the oxidizer
-                [J]. Required for a tank running an energy balance, unused
-                otherwise.
+        Returns:
+            Injector inlet pressure of every line [Pa], keyed by line name.
         """
         pass

--- a/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
+++ b/machwave/models/feed_systems/cycles/stacked_tank_pressure_fed.py
@@ -1,113 +1,139 @@
+from collections.abc import Mapping, Sequence
+
 import machwave.models.feed_systems.base as feed_system_base
+import machwave.models.feed_systems.lines as line_models
 import machwave.models.feed_systems.tank as tank
+import machwave.models.propellants.components as propellant_components
 
 
 class StackedTankPressureFedFeedSystem(feed_system_base.FeedSystem):
     """
-    Represents a bipropellant biliquid rocket engine feed system with stacked tanks.
+    Pressure-fed feed system whose propellant tanks are stacked vertically.
 
-    A stacked tank system is a type of pressure-fed system where the oxidizer and fuel
-    tanks are arranged in a vertical stack. The tanks are separated by a piston and the
-    fuel is pressurized by the oxidizer tank.
+    The tank at the top of the stack pressurizes every tank below it through a
+    piston, so one tank sets the pressure the whole system runs on.
     """
 
     def __init__(
         self,
-        fuel_tank: tank.Tank,
-        oxidizer_tank: tank.Tank,
+        lines: Sequence[line_models.PropellantLine],
+        pressurizing_line: str,
         piston_loss: float = 0.0,
-        oxidizer_line_loss: float = 0.0,
-        fuel_line_loss: float = 0.0,
+        line_losses: Mapping[str, float] | None = None,
     ):
         """
         Initialize the StackedTankPressureFedFeedSystem.
 
         Args:
-            fuel_tank: An instance representing the fuel tank.
-            oxidizer_tank: An instance representing the oxidizer tank.
-            piston_loss: Pressure loss across the piston [Pa]. Default is 0.0.
-            oxidizer_line_loss: Pressure loss along the oxidizer feedline [Pa],
-                stated for the design flow rather than computed from it.
-                Default is 0.0, no line.
-            fuel_line_loss: Pressure loss along the fuel feedline [Pa], stated
-                for the design flow rather than computed from it. Default is
-                0.0, no line.
+            lines: Propellant lines the system feeds, one per propellant.
+            pressurizing_line: Name of the line at the top of the stack, whose
+                tank pressure drives every line.
+            piston_loss: Pressure loss across the piston [Pa], taken by every
+                line below the top of the stack.
+            line_losses: Pressure loss along each feedline [Pa], keyed by line
+                name and stated for the design flow rather than computed from
+                it. A line left out takes no loss.
 
         Raises:
-            ValueError: If any pressure loss is negative.
+            ValueError: If the pressurizing line is not one of the lines, if a
+                loss is keyed by an unknown line, or if any pressure loss is
+                negative.
         """
-        super().__init__(fuel_tank, oxidizer_tank)
+        super().__init__(lines)
 
+        self.pressurizing_line = pressurizing_line
         self.piston_loss = piston_loss
-        self.oxidizer_line_loss = oxidizer_line_loss
-        self.fuel_line_loss = fuel_line_loss
+        self.line_losses = {name: 0.0 for name in self.lines} | dict(line_losses or {})
 
-        self.fuel_tank = fuel_tank
-        self.oxidizer_tank = oxidizer_tank
+        self._validate_pressure_losses()
 
-        self._validate()
-
-    def _validate(self) -> None:
-        """
-        Validate the pressure losses.
-
-        Raises:
-            ValueError: If any pressure loss is negative.
-        """
-        for name, value in (
-            ("piston_loss", self.piston_loss),
-            ("oxidizer_line_loss", self.oxidizer_line_loss),
-            ("fuel_line_loss", self.fuel_line_loss),
-        ):
-            if value < 0.0:
-                raise ValueError(f"{name} must be non-negative, got {value}")
-
-    def get_oxidizer_tank_pressure(
-        self, *, oxidizer_mass: float, oxidizer_internal_energy: float | None = None
-    ) -> float:
-        """
-        Returns the oxidizer-side pressure delivered to the injector [Pa].
-
-        The tank pressure less what the oxidizer line takes.
-
-        Args:
-            oxidizer_mass: Current oxidizer mass in the tank [kg].
-            oxidizer_internal_energy: Current internal energy of the oxidizer
-                [J]. Required for a tank running an energy balance, unused
-                otherwise.
-        """
-        return (
-            self.oxidizer_tank.get_pressure(oxidizer_mass, oxidizer_internal_energy)
-            - self.oxidizer_line_loss
-        )
-
-    def get_fuel_tank_pressure(
-        self,
+    @classmethod
+    def from_oxidizer_and_fuel(
+        cls,
         *,
-        oxidizer_mass: float,
-        fuel_mass: float,
-        fuel_internal_energy: float | None = None,
-        oxidizer_internal_energy: float | None = None,
-    ) -> float:
+        oxidizer_tank: tank.Tank,
+        fuel_tank: tank.Tank,
+        piston_loss: float = 0.0,
+        oxidizer_line_loss: float = 0.0,
+        fuel_line_loss: float = 0.0,
+    ) -> "StackedTankPressureFedFeedSystem":
         """
-        Returns the fuel-side pressure delivered to the injector [Pa].
+        Build the two-line system a biliquid engine runs on.
 
-        In a stacked-tank system the fuel is pressurized by the oxidizer
-        through the piston, so the fuel side starts from the oxidizer tank
-        pressure less the piston pressure loss, and then loses what the fuel
-        line takes. The oxidizer line is not on this path, and neither
-        ``fuel_mass`` nor ``fuel_internal_energy`` is used here.
+        The oxidizer sits at the top of the stack and pressurizes the fuel
+        through the piston. The lines are named "oxidizer" and "fuel", which is
+        how the injector and the simulation state key them.
 
         Args:
-            oxidizer_mass: Current oxidizer mass in the tank [kg].
-            fuel_mass: Current fuel mass in the tank [kg].
-            fuel_internal_energy: Current internal energy of the fuel [J].
-            oxidizer_internal_energy: Current internal energy of the oxidizer
-                [J], which sets the pressure the piston passes on. Required for
-                a tank running an energy balance, unused otherwise.
+            oxidizer_tank: Tank the oxidizer line draws from.
+            fuel_tank: Tank the fuel line draws from.
+            piston_loss: Pressure loss across the piston [Pa].
+            oxidizer_line_loss: Pressure loss along the oxidizer feedline [Pa].
+            fuel_line_loss: Pressure loss along the fuel feedline [Pa].
         """
-        return (
-            self.oxidizer_tank.get_pressure(oxidizer_mass, oxidizer_internal_energy)
-            - self.piston_loss
-            - self.fuel_line_loss
+        return cls(
+            lines=[
+                line_models.PropellantLine(
+                    name="oxidizer",
+                    role=propellant_components.ComponentRole.OXIDIZER,
+                    tank=oxidizer_tank,
+                ),
+                line_models.PropellantLine(
+                    name="fuel",
+                    role=propellant_components.ComponentRole.FUEL,
+                    tank=fuel_tank,
+                ),
+            ],
+            pressurizing_line="oxidizer",
+            piston_loss=piston_loss,
+            line_losses={"oxidizer": oxidizer_line_loss, "fuel": fuel_line_loss},
         )
+
+    def _validate_pressure_losses(self) -> None:
+        if self.pressurizing_line not in self.lines:
+            raise ValueError(
+                f"pressurizing_line {self.pressurizing_line!r} is not one of the "
+                f"lines, got {list(self.lines)}"
+            )
+
+        unknown = [name for name in self.line_losses if name not in self.lines]
+        if unknown:
+            raise ValueError(f"line_losses names {unknown} are not lines of the system")
+
+        if self.piston_loss < 0.0:
+            raise ValueError(
+                f"piston_loss must be non-negative, got {self.piston_loss}"
+            )
+        for name, loss in self.line_losses.items():
+            if loss < 0.0:
+                raise ValueError(
+                    f"line_losses[{name!r}] must be non-negative, got {loss}"
+                )
+
+    def get_inlet_pressures(
+        self, line_states: Mapping[str, line_models.LineState]
+    ) -> dict[str, float]:
+        """
+        Return the pressure delivered to the injector on every line [Pa].
+
+        The line at the top of the stack loses only what its own feedline
+        takes; every line below the piston loses the piston pressure loss too.
+
+        Args:
+            line_states: Fluid mass and internal energy of every line, keyed by
+                line name.
+
+        Returns:
+            Injector inlet pressure of every line [Pa], keyed by line name.
+        """
+        pressurizing_state = line_states[self.pressurizing_line]
+        stack_pressure = self.lines[self.pressurizing_line].tank.get_pressure(
+            pressurizing_state.fluid_mass, pressurizing_state.internal_energy
+        )
+
+        return {
+            name: stack_pressure
+            - (0.0 if name == self.pressurizing_line else self.piston_loss)
+            - self.line_losses[name]
+            for name in self.lines
+        }

--- a/machwave/simulation/biliquid/states.py
+++ b/machwave/simulation/biliquid/states.py
@@ -9,8 +9,11 @@ import machwave.common.fluid_state as fluid_state_models
 import machwave.core.mass_balance as mass_balance
 import machwave.core.performance as performance
 import machwave.core.solvers.rk4 as rk4
+import machwave.models.feed_systems.base as feed_system_base
+import machwave.models.feed_systems.lines as line_models
 import machwave.models.feed_systems.tank as tank_models
 import machwave.models.motors as motors
+import machwave.models.propellants.components as propellant_components
 import machwave.models.propellants.properties as propellant_properties_models
 import machwave.models.thrust_chamber.injector as injector_models
 import machwave.simulation.biliquid.results as biliquid_results
@@ -51,6 +54,25 @@ def get_injector_mass_flows(
         min(fuel_flow, fuel_mass / d_t),
         min(oxidizer_flow, oxidizer_mass / d_t),
     )
+
+
+def get_line_with_role(
+    feed_system: feed_system_base.FeedSystem,
+    role: propellant_components.ComponentRole,
+) -> line_models.PropellantLine:
+    """
+    The one line of the feed system carrying the given role.
+
+    Raises:
+        ValueError: If the feed system does not feed exactly one such line.
+    """
+    lines = feed_system.get_lines_with_role(role)
+    if len(lines) != 1:
+        raise ValueError(
+            f"a biliquid engine feeds exactly one {role} line, got "
+            f"{[line.name for line in lines]}"
+        )
+    return lines[0]
 
 
 def get_total_injector_mass_flow(
@@ -103,8 +125,14 @@ class BiliquidEngineState(simulation_states.MotorState):
             external_pressure=external_pressure,
         )
 
-        oxidizer_tank = motor.feed_system.oxidizer_tank
-        fuel_tank = motor.feed_system.fuel_tank
+        self.oxidizer_line = get_line_with_role(
+            motor.feed_system, propellant_components.ComponentRole.OXIDIZER
+        )
+        self.fuel_line = get_line_with_role(
+            motor.feed_system, propellant_components.ComponentRole.FUEL
+        )
+        oxidizer_tank = self.oxidizer_line.tank
+        fuel_tank = self.fuel_line.tank
 
         self.oxidizer_mass: simulation_states.SimulationStateArray = [
             oxidizer_tank.initial_fluid_mass
@@ -167,37 +195,27 @@ class BiliquidEngineState(simulation_states.MotorState):
         propellant_mass = fuel_mass + oxidizer_mass
         self.propellant_mass.append(propellant_mass)
 
-        fuel_inlet = feed_system.get_fuel_inlet_state(
-            oxidizer_mass=oxidizer_mass,
-            fuel_mass=fuel_mass,
-            fuel_internal_energy=fuel_internal_energy,
-            oxidizer_internal_energy=oxidizer_internal_energy,
+        inlet_states = feed_system.get_inlet_states(
+            {
+                self.fuel_line.name: line_models.LineState(
+                    fluid_mass=fuel_mass, internal_energy=fuel_internal_energy
+                ),
+                self.oxidizer_line.name: line_models.LineState(
+                    fluid_mass=oxidizer_mass, internal_energy=oxidizer_internal_energy
+                ),
+            }
         )
-        oxidizer_inlet = feed_system.get_oxidizer_inlet_state(
-            oxidizer_mass=oxidizer_mass,
-            oxidizer_internal_energy=oxidizer_internal_energy,
-        )
+        fuel_inlet = inlet_states[self.fuel_line.name]
+        oxidizer_inlet = inlet_states[self.oxidizer_line.name]
 
-        fuel_tank_pressure = feed_system.get_fuel_tank_pressure(
-            oxidizer_mass=oxidizer_mass,
-            fuel_mass=fuel_mass,
-            fuel_internal_energy=fuel_internal_energy,
-            oxidizer_internal_energy=oxidizer_internal_energy,
-        )
+        fuel_tank_pressure = fuel_inlet.pressure
         self.fuel_tank_pressure.append(fuel_tank_pressure)
-        oxidizer_tank_pressure = feed_system.get_oxidizer_tank_pressure(
-            oxidizer_mass=oxidizer_mass,
-            oxidizer_internal_energy=oxidizer_internal_energy,
-        )
+        oxidizer_tank_pressure = oxidizer_inlet.pressure
         self.oxidizer_tank_pressure.append(oxidizer_tank_pressure)
 
-        fuel_tank_temperature = feed_system.fuel_tank.get_temperature(
-            fuel_mass, fuel_internal_energy
-        )
+        fuel_tank_temperature = fuel_inlet.temperature
         self.fuel_tank_temperature.append(fuel_tank_temperature)
-        oxidizer_tank_temperature = feed_system.oxidizer_tank.get_temperature(
-            oxidizer_mass, oxidizer_internal_energy
-        )
+        oxidizer_tank_temperature = oxidizer_inlet.temperature
         self.oxidizer_tank_temperature.append(oxidizer_tank_temperature)
 
         is_feeding = (
@@ -316,13 +334,13 @@ class BiliquidEngineState(simulation_states.MotorState):
         self.oxidizer_mass.append(oxidizer_mass - oxidizer_consumed)
 
         self.fuel_internal_energy = self._drain_internal_energy(
-            tank=feed_system.fuel_tank,
+            tank=self.fuel_line.tank,
             internal_energy=fuel_internal_energy,
             fluid_mass=fuel_mass,
             mass_drained=fuel_consumed,
         )
         self.oxidizer_internal_energy = self._drain_internal_energy(
-            tank=feed_system.oxidizer_tank,
+            tank=self.oxidizer_line.tank,
             internal_energy=oxidizer_internal_energy,
             fluid_mass=oxidizer_mass,
             mass_drained=oxidizer_consumed,

--- a/tests/factories/feed_systems.py
+++ b/tests/factories/feed_systems.py
@@ -49,4 +49,8 @@ class StackedTankPressureFedFeedSystemFactory:
             fuel_tank=fuel_tank,
         )
         kwargs.update(overrides)
-        return feed_systems_models.StackedTankPressureFedFeedSystem(**kwargs)
+        return (
+            feed_systems_models.StackedTankPressureFedFeedSystem.from_oxidizer_and_fuel(
+                **kwargs
+            )
+        )

--- a/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
+++ b/tests/test_models/test_propulsion/test_feed_systems/test_stacked_tank_pressure_fed.py
@@ -1,75 +1,134 @@
 import pytest
 
+import machwave.models.feed_systems as feed_systems_models
+import machwave.models.feed_systems.lines as line_models
 import machwave.models.feed_systems.tank as tank_models
-from tests.factories import StackedTankPressureFedFeedSystemFactory
+import machwave.models.propellants as propellants_models
+from tests.factories import (
+    PropellantLineFactory,
+    StackedTankPressureFedFeedSystemFactory,
+    TankFactory,
+)
 
 
-def test_oxidizer_inlet_state_reads_the_oxidizer_tank():
-    """The oxidizer inlet carries the tank fluid at the tank state."""
-    oxidizer_mass = 5.0
-    oxidizer_tank = tank_models.Tank(
-        fluid_name="N2O",
-        volume=0.01,
-        temperature=293.0,
-        initial_fluid_mass=oxidizer_mass,
-    )
-    feed_system = StackedTankPressureFedFeedSystemFactory.build(
-        oxidizer_tank=oxidizer_tank,
-        oxidizer_line_loss=3e5,
-    )
-
-    inlet = feed_system.get_oxidizer_inlet_state(oxidizer_mass=oxidizer_mass)
-
-    assert inlet.fluid_name == "N2O"
-    assert inlet.pressure == pytest.approx(
-        feed_system.get_oxidizer_tank_pressure(oxidizer_mass=oxidizer_mass)
-    )
-    assert inlet.temperature == pytest.approx(
-        oxidizer_tank.get_temperature(oxidizer_mass)
-    )
-    assert inlet.density == pytest.approx(oxidizer_tank.get_density(oxidizer_mass))
+def line_states(feed_system):
+    """The state of every line, as the tanks were loaded."""
+    return {name: line.initial_state for name, line in feed_system.lines.items()}
 
 
-def test_fuel_inlet_state_is_piston_pressurized_fuel():
-    """The fuel inlet carries fuel at the piston-pressurized upstream pressure."""
-    feed_system = StackedTankPressureFedFeedSystemFactory.build(piston_loss=2e5)
-    oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
-    fuel_mass = feed_system.fuel_tank.initial_fluid_mass
+def build_triliquid(**overrides):
+    """A stack of an oxidizer over a fuel and a diluent, both below the piston."""
+    lines = [
+        PropellantLineFactory.build(
+            name="oxidizer", role="oxidizer", tank=TankFactory.build(fluid_name="N2O")
+        ),
+        PropellantLineFactory.build(
+            name="fuel",
+            role="fuel",
+            tank=TankFactory.build(fluid_name="Ethanol", initial_fluid_mass=3.0),
+        ),
+        PropellantLineFactory.build(
+            name="diluent",
+            role="additive",
+            tank=TankFactory.build(fluid_name="Water", initial_fluid_mass=1.0),
+        ),
+    ]
+    kwargs = dict(lines=lines, pressurizing_line="oxidizer")
+    kwargs.update(overrides)
+    return feed_systems_models.StackedTankPressureFedFeedSystem(**kwargs)
 
-    inlet = feed_system.get_fuel_inlet_state(
-        oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
-    )
 
-    assert inlet.fluid_name == feed_system.fuel_tank.fluid_name
-    assert inlet.pressure == pytest.approx(
-        feed_system.oxidizer_tank.get_pressure(oxidizer_mass) - 2e5
-    )
-    assert inlet.temperature == pytest.approx(
-        feed_system.fuel_tank.get_temperature(fuel_mass)
-    )
-    assert inlet.density == pytest.approx(feed_system.fuel_tank.get_density(fuel_mass))
+class TestInletStates:
+    def test_every_line_gets_a_state_in_one_call(self):
+        feed_system = build_triliquid()
+
+        inlet_states = feed_system.get_inlet_states(line_states(feed_system))
+
+        assert set(inlet_states) == {"oxidizer", "fuel", "diluent"}
+
+    def test_the_oxidizer_inlet_reads_the_oxidizer_tank(self):
+        oxidizer_mass = 5.0
+        oxidizer_tank = tank_models.Tank(
+            fluid_name="N2O",
+            volume=0.01,
+            temperature=293.0,
+            initial_fluid_mass=oxidizer_mass,
+        )
+        feed_system = StackedTankPressureFedFeedSystemFactory.build(
+            oxidizer_tank=oxidizer_tank,
+            oxidizer_line_loss=3e5,
+        )
+
+        inlet = feed_system.get_inlet_states(line_states(feed_system))["oxidizer"]
+
+        assert inlet.fluid_name == "N2O"
+        assert inlet.pressure == pytest.approx(
+            oxidizer_tank.get_pressure(oxidizer_mass) - 3e5
+        )
+        assert inlet.temperature == pytest.approx(
+            oxidizer_tank.get_temperature(oxidizer_mass)
+        )
+        assert inlet.density == pytest.approx(oxidizer_tank.get_density(oxidizer_mass))
+
+    def test_the_fuel_inlet_is_piston_pressurized_fuel(self):
+        feed_system = StackedTankPressureFedFeedSystemFactory.build(piston_loss=2e5)
+        oxidizer_tank = feed_system.lines["oxidizer"].tank
+        fuel_tank = feed_system.lines["fuel"].tank
+        oxidizer_mass = oxidizer_tank.initial_fluid_mass
+        fuel_mass = fuel_tank.initial_fluid_mass
+
+        inlet = feed_system.get_inlet_states(line_states(feed_system))["fuel"]
+
+        assert inlet.fluid_name == fuel_tank.fluid_name
+        assert inlet.pressure == pytest.approx(
+            oxidizer_tank.get_pressure(oxidizer_mass) - 2e5
+        )
+        assert inlet.temperature == pytest.approx(fuel_tank.get_temperature(fuel_mass))
+        assert inlet.density == pytest.approx(fuel_tank.get_density(fuel_mass))
+
+    def test_a_third_line_is_pressurized_through_the_piston_too(self):
+        feed_system = build_triliquid(piston_loss=2e5, line_losses={"diluent": 1e5})
+        oxidizer_tank = feed_system.lines["oxidizer"].tank
+
+        inlet = feed_system.get_inlet_states(line_states(feed_system))["diluent"]
+
+        assert inlet.fluid_name == "Water"
+        assert inlet.pressure == pytest.approx(
+            oxidizer_tank.get_pressure(oxidizer_tank.initial_fluid_mass) - 2e5 - 1e5
+        )
+
+    def test_rejects_a_missing_line_state(self):
+        feed_system = build_triliquid()
+        states = line_states(feed_system)
+        del states["diluent"]
+
+        with pytest.raises(ValueError, match="diluent"):
+            feed_system.get_inlet_states(states)
 
 
 class TestFeedlineLoss:
     def test_no_line_leaves_the_tank_pressure_alone(self):
         feed_system = StackedTankPressureFedFeedSystemFactory.build()
-        oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
+        oxidizer_tank = feed_system.lines["oxidizer"].tank
 
-        assert feed_system.get_oxidizer_tank_pressure(
-            oxidizer_mass=oxidizer_mass
-        ) == feed_system.oxidizer_tank.get_pressure(oxidizer_mass)
+        pressures = feed_system.get_inlet_pressures(line_states(feed_system))
+
+        assert pressures["oxidizer"] == oxidizer_tank.get_pressure(
+            oxidizer_tank.initial_fluid_mass
+        )
 
     def test_the_oxidizer_line_comes_off_the_oxidizer_side(self):
         oxidizer_line_loss = 3e5
         feed_system = StackedTankPressureFedFeedSystemFactory.build(
             oxidizer_line_loss=oxidizer_line_loss
         )
-        oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
+        oxidizer_tank = feed_system.lines["oxidizer"].tank
 
-        assert feed_system.get_oxidizer_tank_pressure(
-            oxidizer_mass=oxidizer_mass
-        ) == pytest.approx(
-            feed_system.oxidizer_tank.get_pressure(oxidizer_mass) - oxidizer_line_loss
+        pressures = feed_system.get_inlet_pressures(line_states(feed_system))
+
+        assert pressures["oxidizer"] == pytest.approx(
+            oxidizer_tank.get_pressure(oxidizer_tank.initial_fluid_mass)
+            - oxidizer_line_loss
         )
 
     def test_the_fuel_side_takes_the_piston_and_its_own_line(self):
@@ -80,14 +139,13 @@ class TestFeedlineLoss:
             fuel_line_loss=fuel_line_loss,
             oxidizer_line_loss=3e5,
         )
-        oxidizer_mass = feed_system.oxidizer_tank.initial_fluid_mass
-        fuel_mass = feed_system.fuel_tank.initial_fluid_mass
+        oxidizer_tank = feed_system.lines["oxidizer"].tank
+
+        pressures = feed_system.get_inlet_pressures(line_states(feed_system))
 
         # The oxidizer line is not on the fuel path.
-        assert feed_system.get_fuel_tank_pressure(
-            oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
-        ) == pytest.approx(
-            feed_system.oxidizer_tank.get_pressure(oxidizer_mass)
+        assert pressures["fuel"] == pytest.approx(
+            oxidizer_tank.get_pressure(oxidizer_tank.initial_fluid_mass)
             - piston_loss
             - fuel_line_loss
         )
@@ -95,24 +153,77 @@ class TestFeedlineLoss:
     def test_a_line_holds_the_inlet_pressure_below_the_lossless_one(self):
         with_line = StackedTankPressureFedFeedSystemFactory.build(fuel_line_loss=5e5)
         without_line = StackedTankPressureFedFeedSystemFactory.build()
-        fuel_mass = with_line.fuel_tank.initial_fluid_mass
-        oxidizer_mass = with_line.oxidizer_tank.initial_fluid_mass
 
         pressures = [
-            feed_system.get_fuel_inlet_state(
-                oxidizer_mass=oxidizer_mass, fuel_mass=fuel_mass
-            ).pressure
+            feed_system.get_inlet_states(line_states(feed_system))["fuel"].pressure
             for feed_system in (with_line, without_line)
         ]
 
         assert 0.0 < pressures[0] < pressures[1]
 
 
+class TestLines:
+    def test_the_initial_propellant_mass_adds_up_every_line(self):
+        feed_system = build_triliquid()
+
+        assert feed_system.get_initial_propellant_mass() == pytest.approx(
+            sum(line.tank.initial_fluid_mass for line in feed_system.lines.values())
+        )
+
+    def test_lines_are_found_by_role(self):
+        feed_system = build_triliquid()
+
+        oxidizer_lines = feed_system.get_lines_with_role(
+            propellants_models.ComponentRole.OXIDIZER
+        )
+        additive_lines = feed_system.get_lines_with_role(
+            propellants_models.ComponentRole.ADDITIVE
+        )
+
+        assert [line.name for line in oxidizer_lines] == ["oxidizer"]
+        assert [line.name for line in additive_lines] == ["diluent"]
+
+    def test_rejects_a_system_without_lines(self):
+        with pytest.raises(ValueError, match="at least one"):
+            feed_systems_models.StackedTankPressureFedFeedSystem(
+                lines=[], pressurizing_line="oxidizer"
+            )
+
+    def test_rejects_two_lines_sharing_a_name(self):
+        line = PropellantLineFactory.build(name="oxidizer")
+
+        with pytest.raises(ValueError, match="unique"):
+            feed_systems_models.StackedTankPressureFedFeedSystem(
+                lines=[line, line], pressurizing_line="oxidizer"
+            )
+
+
 class TestValidation:
-    @pytest.mark.parametrize(
-        "field",
-        ["piston_loss", "oxidizer_line_loss", "fuel_line_loss"],
-    )
-    def test_rejects_a_negative_pressure_loss(self, field):
-        with pytest.raises(ValueError, match=field):
-            StackedTankPressureFedFeedSystemFactory.build(**{field: -1.0})
+    def test_rejects_a_pressurizing_line_the_system_does_not_feed(self):
+        with pytest.raises(ValueError, match="pressurizing_line"):
+            build_triliquid(pressurizing_line="pressurant")
+
+    def test_rejects_a_loss_keyed_by_an_unknown_line(self):
+        with pytest.raises(ValueError, match="coolant"):
+            build_triliquid(line_losses={"coolant": 1e5})
+
+    def test_rejects_a_negative_piston_loss(self):
+        with pytest.raises(ValueError, match="piston_loss"):
+            build_triliquid(piston_loss=-1.0)
+
+    @pytest.mark.parametrize("line_name", ["oxidizer", "fuel"])
+    def test_rejects_a_negative_line_loss(self, line_name):
+        with pytest.raises(ValueError, match=line_name):
+            build_triliquid(line_losses={line_name: -1.0})
+
+
+class TestInitialState:
+    def test_the_line_state_starts_at_the_tank_loading(self):
+        feed_system = StackedTankPressureFedFeedSystemFactory.build()
+
+        state = feed_system.lines["fuel"].initial_state
+
+        assert isinstance(state, line_models.LineState)
+        assert state.fluid_mass == pytest.approx(
+            feed_system.lines["fuel"].tank.initial_fluid_mass
+        )

--- a/tests/test_simulations/test_biliquid_tank_energy_balance.py
+++ b/tests/test_simulations/test_biliquid_tank_energy_balance.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+import machwave.models.feed_systems as feed_systems_models
 import machwave.models.feed_systems.tank as tank_models
 import machwave.simulation.biliquid as biliquid_simulation
 from tests.test_simulations import motor_builders
@@ -28,8 +29,15 @@ OXIDIZER_TANK = dict(
 
 def build(isothermal):
     motor, params = motor_builders.build_1kn_biliquid_engine()
-    motor.feed_system.oxidizer_tank = tank_models.Tank(
-        **OXIDIZER_TANK, isothermal=isothermal
+    feed_system = motor.feed_system
+    motor.feed_system = (
+        feed_systems_models.StackedTankPressureFedFeedSystem.from_oxidizer_and_fuel(
+            oxidizer_tank=tank_models.Tank(**OXIDIZER_TANK, isothermal=isothermal),
+            fuel_tank=feed_system.lines["fuel"].tank,
+            piston_loss=feed_system.piston_loss,
+            oxidizer_line_loss=feed_system.line_losses["oxidizer"],
+            fuel_line_loss=feed_system.line_losses["fuel"],
+        )
     )
     return motor, params
 
@@ -101,7 +109,7 @@ def test_the_state_carries_the_energy_only_for_an_energy_balance():
 
     assert isothermal_state.oxidizer_internal_energy is None
     assert energy_balance_state.oxidizer_internal_energy == pytest.approx(
-        energy_balance_motor.feed_system.oxidizer_tank.initial_internal_energy
+        energy_balance_motor.feed_system.lines["oxidizer"].tank.initial_internal_energy
     )
 
 
@@ -112,7 +120,7 @@ def test_draining_takes_the_outflow_enthalpy_out():
         igniter_pressure=params.igniter_pressure,
         external_pressure=params.external_pressure,
     )
-    tank = motor.feed_system.oxidizer_tank
+    tank = motor.feed_system.lines["oxidizer"].tank
     internal_energy_before = state.oxidizer_internal_energy
     assert internal_energy_before is not None
     oxidizer_mass_before = state.oxidizer_mass[-1]


### PR DESCRIPTION
Closes #493. Stacked on #498.

The feed system took a fuel tank and an oxidizer tank and exposed one pressure hook per side, each taking every other side's fluid mass and internal energy — a signature that grows with the square of the propellant count, and that cannot express a third line at all.

- `FeedSystem` now holds `lines: dict[str, PropellantLine]` and exposes `get_inlet_states(line_states)`, which returns the injector inlet state of every line at once. Cycles implement the single abstract hook `get_inlet_pressures(line_states)`; the base class assembles the fluid states from the tanks.
- `get_fuel_tank_pressure`, `get_oxidizer_tank_pressure`, `get_fuel_inlet_state` and `get_oxidizer_inlet_state` are gone.
- `StackedTankPressureFedFeedSystem` stacks any number of lines below the pressurizing one, with per-line feedline losses. `StackedTankPressureFedFeedSystem.from_oxidizer_and_fuel` is the two-line convenience constructor, so the biliquid call sites and the example stay readable.
- `BiliquidEngineState` resolves its oxidizer and fuel lines by role and feeds the new call; carrying the state per line is #495.