### PR TITLE
Add a helper that resolves optional dependencies

### DIFF
--- a/docs/api/common.md
+++ b/docs/api/common.md
@@ -6,6 +6,7 @@ model package.
 - `FluidState` — A fluid at a thermodynamic state point: fluid name, pressure, temperature, and density. What a feed system hands the injector, so neither package has to import the other.
 - `DryMassProperties` — Mass, center of gravity, and inertia tensor of a device's dry structure.
 - Array manipulation helpers and a `@timing` decorator for profiling.
+- `require()` — Imports an optional dependency, raising `MissingOptionalDependencyError` naming the packaging extra that ships it.
 
 ::: machwave.common.fluid_state
 
@@ -16,3 +17,5 @@ model package.
 ::: machwave.common.decorators
 
 ::: machwave.common.objects
+
+::: machwave.common.extras

--- a/machwave/adapters/rocketpy/base.py
+++ b/machwave/adapters/rocketpy/base.py
@@ -4,11 +4,13 @@ import typing
 import numpy as np
 import numpy.typing as npt
 
+import machwave.common.extras as extras
+
 try:
     import rocketpy
     import rocketpy.motors as rocketpy_motors
 except ImportError as e:  # pragma: no cover - exercised only without rocketpy
-    raise ImportError("RocketPy adapters require the `rocketpy` package") from e
+    raise extras.MissingOptionalDependencyError("rocketpy", extras.ROCKETPY) from e
 
 if typing.TYPE_CHECKING:
     import machwave.simulation as ib_simulation

--- a/machwave/common/extras.py
+++ b/machwave/common/extras.py
@@ -1,0 +1,87 @@
+"""
+Resolution of the optional dependencies behind Machwave's packaging extras.
+
+Modules reached only once a feature is used guard their own import at module
+level and re-raise `MissingOptionalDependencyError`; that keeps the third-party
+names real and fully typed. `require` is for modules on the import path, which
+must stay importable without their dependency. It returns the module untyped,
+so prefer the module-level guard wherever both work.
+"""
+
+import importlib
+import types
+
+CEA = "cea"
+LIQUID = "liquid"
+FMM = "fmm"
+PLOTS = "plots"
+ROCKETPY = "rocketpy"
+
+# Default wording per extra, as a plural noun phrase, so that the message reads
+# "<feature> require the `<distribution>` package".
+_FEATURE_BY_EXTRA = {
+    CEA: "Thermochemical properties computed from propellant composition",
+    LIQUID: "Tank and injector fluid properties",
+    FMM: "Non-BATES grain geometries",
+    PLOTS: "Machwave's built-in plots",
+    ROCKETPY: "RocketPy adapters",
+}
+
+# Import name to distribution name, where the two differ.
+_DISTRIBUTION_BY_MODULE = {
+    "CoolProp": "coolprop",
+    "skfmm": "scikit-fmm",
+    "skimage": "scikit-image",
+}
+
+
+class MissingOptionalDependencyError(ImportError):
+    """Raised when a feature needs an optional dependency that is not installed."""
+
+    def __init__(
+        self, module_name: str, extra: str, feature: str | None = None
+    ) -> None:
+        """
+        Build the error from the missing dependency and the extra that ships it.
+
+        Args:
+            module_name: Import name of the package, e.g. `skimage.measure`.
+            extra: Packaging extra that installs it.
+            feature: Plural noun phrase naming the feature, overriding the default
+                wording for `extra`. Use it when one extra gates more than one
+                feature.
+        """
+        top_level = module_name.partition(".")[0]
+        distribution = _DISTRIBUTION_BY_MODULE.get(top_level, top_level)
+        feature = feature or _FEATURE_BY_EXTRA[extra]
+
+        self.extra = extra
+
+        super().__init__(
+            f"{feature} require the `{distribution}` package. "
+            f"Install it with `pip install machwave[{extra}]`."
+        )
+
+
+def require(
+    module_name: str, extra: str, feature: str | None = None
+) -> types.ModuleType:
+    """
+    Import an optional dependency, naming the extra that ships it on failure.
+
+    Args:
+        module_name: Import name of the package, e.g. `skimage.measure`.
+        extra: Packaging extra that installs it.
+        feature: Plural noun phrase naming the feature, overriding the default
+            wording for `extra`.
+
+    Returns:
+        The imported module.
+
+    Raises:
+        MissingOptionalDependencyError: If the package is not installed.
+    """
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as e:
+        raise MissingOptionalDependencyError(module_name, extra, feature) from e

--- a/tests/test_common/test_extras.py
+++ b/tests/test_common/test_extras.py
@@ -1,0 +1,84 @@
+import json
+
+import pytest
+
+import machwave.common.extras as extras
+
+ALL_EXTRAS = [
+    extras.CEA,
+    extras.LIQUID,
+    extras.FMM,
+    extras.PLOTS,
+    extras.ROCKETPY,
+]
+
+
+def test_require_returns_an_installed_module():
+    assert extras.require("json", extras.FMM) is json
+
+
+def test_require_returns_the_named_submodule():
+    assert extras.require("json.decoder", extras.FMM).__name__ == "json.decoder"
+
+
+def test_require_raises_for_a_missing_package():
+    with pytest.raises(extras.MissingOptionalDependencyError) as exc_info:
+        extras.require("machwave_absent_dependency", extras.FMM)
+
+    message = str(exc_info.value)
+
+    assert "Non-BATES grain geometries" in message
+    assert "`machwave_absent_dependency`" in message
+    assert "pip install machwave[fmm]" in message
+
+
+def test_require_chains_the_original_import_error():
+    with pytest.raises(extras.MissingOptionalDependencyError) as exc_info:
+        extras.require("machwave_absent_dependency", extras.FMM)
+
+    assert isinstance(exc_info.value.__cause__, ImportError)
+
+
+def test_missing_optional_dependency_error_is_an_import_error():
+    assert issubclass(extras.MissingOptionalDependencyError, ImportError)
+
+
+def test_missing_optional_dependency_error_exposes_the_extra():
+    assert (
+        extras.MissingOptionalDependencyError("skfmm", extras.FMM).extra == extras.FMM
+    )
+
+
+@pytest.mark.parametrize(
+    "module_name, expected_distribution",
+    [
+        ("CoolProp.CoolProp", "coolprop"),
+        ("skfmm", "scikit-fmm"),
+        ("skimage.measure", "scikit-image"),
+        ("trimesh", "trimesh"),
+        ("rocketcea.cea_obj", "rocketcea"),
+        ("plotly.graph_objects", "plotly"),
+    ],
+)
+def test_error_names_the_distribution_not_the_import_name(
+    module_name, expected_distribution
+):
+    error = extras.MissingOptionalDependencyError(module_name, extras.FMM)
+
+    assert f"`{expected_distribution}` package" in str(error)
+
+
+def test_feature_overrides_the_default_wording():
+    error = extras.MissingOptionalDependencyError(
+        "trimesh", extras.FMM, "STL grain segments"
+    )
+
+    assert str(error).startswith("STL grain segments require the `trimesh` package")
+    assert "pip install machwave[fmm]" in str(error)
+
+
+@pytest.mark.parametrize("extra", ALL_EXTRAS)
+def test_every_extra_has_default_wording(extra):
+    assert str(extras.MissingOptionalDependencyError("package", extra)).endswith(
+        f"Install it with `pip install machwave[{extra}]`."
+    )


### PR DESCRIPTION
Closes #518. Stacked on master.

Nothing in `machwave/` resolved an optional dependency except the RocketPy adapter's own guard, and the packaging extras need the same behaviour in five places.

- `machwave/common/extras.py` holds the extra names, a `MissingOptionalDependencyError` that names the missing distribution and the `pip install machwave[...]` command, and a `require(module_name, extra)` that imports a package or raises it. It is the only place an extra name appears in `machwave/`.
- The error maps import name to distribution name where they differ, so a missing `skimage.measure` reports `scikit-image` rather than `skimage`.
- `MissingOptionalDependencyError` subclasses `ImportError` rather than `Exception`, a deliberate departure from the convention the other custom errors follow, so that existing `except ImportError` handlers and the contract at `docs/api/adapters/rocketpy.md:137` keep working.
- The module docstring records which of the two patterns to reach for. A module reached only once a feature is used guards its own import at module level, which keeps the third-party names real and fully typed; `require` is for modules that sit on the import path and so must stay importable without their dependency, and it hands back the module untyped. Prefer the guard wherever both work.
- The RocketPy guard moves onto it. Its message keeps its exact wording and gains the install command.

Nothing else uses the helper yet; #527 through #530 move each dependency onto it.