### PR TITLE
Defer the rocketcea import out of the module import path

### DIFF
--- a/machwave/models/propellants/categories/base.py
+++ b/machwave/models/propellants/categories/base.py
@@ -1,11 +1,13 @@
 import abc
 import enum
 import functools
-
-import machwave.services.cea as cea_service
+import typing
 
 from .. import components as propellant_components
 from .. import properties as propellant_properties
+
+if typing.TYPE_CHECKING:
+    import machwave.services.cea as cea_service
 
 # Elements that keep their CEA combustion products gaseous at chamber conditions
 # (above 1000K and 10 bar)
@@ -62,7 +64,7 @@ class Propellant(abc.ABC):
         self._evaluation_cache: dict = {}
 
     @functools.cached_property
-    def thermochemical_service(self) -> cea_service.RocketCEAService:
+    def thermochemical_service(self) -> "cea_service.RocketCEAService":
         """Get thermochemical service, cached."""
         return self._get_thermochemical_service()
 
@@ -91,7 +93,7 @@ class Propellant(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _get_thermochemical_service(self) -> cea_service.RocketCEAService:
+    def _get_thermochemical_service(self) -> "cea_service.RocketCEAService":
         """
         Create thermochemical service for this propellant.
 
@@ -177,6 +179,7 @@ class Propellant(abc.ABC):
 
         Raises:
             ValueError: If evaluation fails.
+            MissingOptionalDependencyError: If the `cea` extra is not installed.
         """
         quantized_chamber_pressure = (
             round(chamber_pressure / self.CHAMBER_PRESSURE_QUANTIZATION_PA)

--- a/machwave/models/propellants/categories/biliquid.py
+++ b/machwave/models/propellants/categories/biliquid.py
@@ -1,5 +1,3 @@
-import machwave.services.cea as cea_service
-
 from .. import components as propellant_components
 from . import base as propellant_base
 
@@ -77,7 +75,14 @@ class BiliquidPropellant(propellant_base.Propellant):
 
         Returns:
             RocketCEAService instance.
+
+        Raises:
+            ValueError: If creating the CEA object for the oxidizer and fuel
+                fails.
+            MissingOptionalDependencyError: If the `cea` extra is not installed.
         """
+        import machwave.services.cea as cea_service
+
         fuel = self._get_fuel()
         oxidizer = self._get_oxidizer()
 

--- a/machwave/models/propellants/categories/solid.py
+++ b/machwave/models/propellants/categories/solid.py
@@ -1,5 +1,3 @@
-import machwave.services.cea as cea_service
-
 from .. import components as propellant_components
 from .. import properties as propellant_properties
 from . import base as propellant_base
@@ -125,7 +123,14 @@ class SolidPropellant(propellant_base.Propellant):
 
         Returns:
             RocketCEAService instance.
+
+        Raises:
+            ValueError: If registering the propellant with CEA or creating the
+                CEA object fails.
+            MissingOptionalDependencyError: If the `cea` extra is not installed.
         """
+        import machwave.services.cea as cea_service
+
         components_data = [
             comp.to_cea_dict(weight_percent=mf * 100.0)
             for comp, mf in zip(self.components, self.mass_fractions)

--- a/machwave/services/cea.py
+++ b/machwave/services/cea.py
@@ -3,14 +3,18 @@
 import re
 from uuid import uuid4
 
-from rocketcea.cea_obj import (
-    CEA_Obj,
-    add_new_fuel,
-    add_new_oxidizer,
-    add_new_propellant,
-)
-
+import machwave.common.extras as extras
 import machwave.core.conversions as conversions
+
+try:
+    from rocketcea.cea_obj import (
+        CEA_Obj,
+        add_new_fuel,
+        add_new_oxidizer,
+        add_new_propellant,
+    )
+except ImportError as e:  # pragma: no cover - exercised only without rocketcea
+    raise extras.MissingOptionalDependencyError("rocketcea", extras.CEA) from e
 
 
 def normalize_custom_propellant_name(name: str) -> str:


### PR DESCRIPTION
Closes #519. Stacked on #526.

`machwave/services/cea.py` imported `rocketcea` at module level and is reached from all three propellant category modules, so `import machwave` pulled it in even though every shipped solid formulation carries a precomputed properties block and never queries NASA CEA.

- The service module guards its own import through the helper. It is a leaf — nothing reaches it except a function-local import — so the whole module is free to fail, which keeps `CEA_Obj` a real, fully-typed name.
- Both `_get_thermochemical_service` overrides import it inside the function body, so the failure surfaces when a propellant genuinely needs CEA.
- `categories/base.py` needed the module only for two return annotations; those move under `typing.TYPE_CHECKING` with quoted forward references, matching how the RocketPy adapters already do it.

Docstrings, after review feedback: the overrides propagate `ValueError` from `create_cea_service` and never documented it, so adding a `Raises:` section with only the new error would have read as a complete list when it was not. Both now carry it. `Propellant.evaluate` also documents the missing extra — that is the public path a caller actually reaches, and the one mkdocstrings renders.

Verified: `import machwave` no longer loads rocketcea, and neither does evaluating a shipped solid formulation. Evaluating `LOX_LH2_6_0` still does, and returns an unchanged flame temperature of 3467.9 K. Full suite passes (1197 passed, 8 skipped) as does `make check`.