### PR TITLE
Defer the CoolProp import out of the module import path

### DIFF
--- a/machwave/core/two_phase_flow.py
+++ b/machwave/core/two_phase_flow.py
@@ -1,6 +1,9 @@
+import typing
+
 import numpy as np
 
-import machwave.services.coolprop as coolprop_service
+if typing.TYPE_CHECKING:
+    import machwave.services.coolprop as coolprop_service
 
 
 def get_homogeneous_equilibrium_mass_flux(
@@ -31,7 +34,10 @@ def get_homogeneous_equilibrium_mass_flux(
 
     Raises:
         ValueError: If the number of sweep points is less than 2.
+        MissingOptionalDependencyError: If the `liquid` extra is not installed.
     """
+    import machwave.services.coolprop as coolprop_service
+
     if sweep_points < 2:
         raise ValueError("sweep_points must be at least 2")
 
@@ -61,7 +67,7 @@ def get_homogeneous_equilibrium_mass_flux(
 
 
 def _get_stagnation_enthalpy_and_entropy(
-    coolprop: coolprop_service.CoolPropService,
+    coolprop: "coolprop_service.CoolPropService",
     temperature: float,
     pressure: float,
 ) -> tuple[float, float]:
@@ -90,7 +96,7 @@ def _get_stagnation_enthalpy_and_entropy(
 
 
 def _get_isentropic_mass_flux(
-    coolprop: coolprop_service.CoolPropService,
+    coolprop: "coolprop_service.CoolPropService",
     pressure: float,
     enthalpy_upstream: float,
     entropy_upstream: float,

--- a/machwave/models/feed_systems/tank.py
+++ b/machwave/models/feed_systems/tank.py
@@ -1,8 +1,6 @@
 import dataclasses
 import functools
 
-import machwave.services.coolprop as coolprop_service
-
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class TankFluidState:
@@ -82,7 +80,10 @@ class Tank:
             ValueError: If the fluid is unknown to CoolProp, if any argument is
                 outside its valid physical range, or if the initial fill is
                 denser than the saturated liquid.
+            MissingOptionalDependencyError: If the `liquid` extra is not installed.
         """
+        import machwave.services.coolprop as coolprop_service
+
         self.fluid_name = fluid_name
         self.volume = volume
         self.temperature = temperature

--- a/machwave/services/coolprop.py
+++ b/machwave/services/coolprop.py
@@ -1,6 +1,11 @@
 """Fluid property service wrapper around CoolProp."""
 
-import CoolProp.CoolProp as CP
+import machwave.common.extras as extras
+
+try:
+    import CoolProp.CoolProp as CP
+except ImportError as e:  # pragma: no cover - exercised only without coolprop
+    raise extras.MissingOptionalDependencyError("CoolProp", extras.LIQUID) from e
 
 
 class CoolPropService:


### PR DESCRIPTION
Closes #520. Stacked on #527.

`machwave/services/coolprop.py` imported CoolProp at module level and was reached twice on the import path: through `machwave/models/feed_systems/tank.py`, and through the injector's homogeneous-equilibrium mass flux in `machwave/core/two_phase_flow.py`.

- The service module guards its own import through the helper.
- `Tank.__init__` and `get_homogeneous_equilibrium_mass_flux` import it as the first statement of their bodies, so the guard is unconditional and the failure surfaces at construction rather than partway through a burn.
- The two `CoolPropService` parameter annotations in `two_phase_flow.py` move under `typing.TYPE_CHECKING`.

Verified: neither `import machwave` nor `import machwave.models.feed_systems` loads CoolProp; constructing a `Tank` does, and its N2O saturation pressure is unchanged at 5052509.3 Pa. Full suite passes (1195 passed, 2 skipped) as does `make check`.