### PR TITLE
Defer the Fast Marching Method imports out of the module import path

### DIFF
--- a/machwave/models/grain/fmm/_3d.py
+++ b/machwave/models/grain/fmm/_3d.py
@@ -6,12 +6,11 @@ from abc import ABC
 from collections.abc import Callable
 
 import numpy as np
-import skfmm
 from numpy.typing import NDArray
 from scipy.interpolate import interp1d
 from scipy.ndimage import binary_erosion
-from skimage import measure
 
+import machwave.common.extras as extras
 import machwave.core.filters as filters
 import machwave.core.geometric as geometric
 import machwave.core.mechanics as mechanics
@@ -41,6 +40,7 @@ def _compute_iso_surface_area(
     grid_spacing: tuple[float, float, float],
 ) -> float:
     """Marching-cubes area [m^2] of one regression iso-level, 0 if empty."""
+    measure = extras.require("skimage.measure", extras.FMM)
     try:
         vertices, faces, _, _ = measure.marching_cubes(
             distance_field, level=level, spacing=grid_spacing
@@ -298,13 +298,15 @@ class FMMGrainSegment3D(fmm_base.FMMGrainSegment, grain.GrainSegment3D, ABC):
         # and y axes, because the 3D grid is anisotropic
         axial_grid_spacing = self.get_axial_grid_spacing()
         radial_grid_spacing = self.get_radial_grid_spacing()
+        skfmm = extras.require("skfmm", extras.FMM)
         distance = skfmm.distance(
             self._pad_exposed_ends(masked_face),
-            dx=[axial_grid_spacing, radial_grid_spacing, radial_grid_spacing],  # type: ignore[arg-type]
+            dx=[axial_grid_spacing, radial_grid_spacing, radial_grid_spacing],
         )
         # The padded field keeps the end faces closed for the burn area mesh.
-        self.padded_regression_map = distance * (2.0 / self.outer_diameter)
-        return self._strip_exposed_ends(self.padded_regression_map)
+        padded_regression_map = distance * (2.0 / self.outer_diameter)
+        self.padded_regression_map = padded_regression_map
+        return self._strip_exposed_ends(padded_regression_map)
 
     def get_padded_regression_map(self) -> np.ndarray:
         """Return the regression map including the void slice past each exposed end."""

--- a/machwave/models/grain/fmm/base.py
+++ b/machwave/models/grain/fmm/base.py
@@ -2,10 +2,10 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import numpy as np
-import skfmm
 from scipy.ndimage import binary_erosion
 from numpy.typing import NDArray
 
+import machwave.common.extras as extras
 import machwave.models.grain as grain
 import machwave.models.grain.base as grain_base
 
@@ -33,7 +33,14 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
             inhibited_surfaces: Surfaces inhibited from burning.
             grid_resolution: Resolution of the face map, x and y axes.
             density_ratio: Ratio of real to ideal propellant density.
+
+        Raises:
+            GrainGeometryError: If the segment geometry is invalid.
+            MissingOptionalDependencyError: If the `fmm` extra is not installed.
         """
+        extras.require("skfmm", extras.FMM)
+        extras.require("skimage.measure", extras.FMM)
+
         self.grid_resolution = grid_resolution
 
         # Cache variables:
@@ -195,6 +202,7 @@ class FMMGrainSegment(grain.GrainSegment, ABC):
 
     def _compute_regression_distance(self, masked_face: np.ndarray) -> np.ndarray:
         """Return the regression distance from the burning surface in normalized web units."""
+        skfmm = extras.require("skfmm", extras.FMM)
         distance = skfmm.distance(masked_face, dx=self.get_radial_grid_spacing())
         return distance * (2.0 / self.outer_diameter)
 

--- a/machwave/models/grain/fmm/contours.py
+++ b/machwave/models/grain/fmm/contours.py
@@ -1,5 +1,6 @@
 import numpy as np
-from skimage import measure
+
+import machwave.common.extras as extras
 
 
 def get_iso_contours(
@@ -18,7 +19,12 @@ def get_iso_contours(
     Returns:
         A list of float64 arrays, where each array represents a contour.
         Each contour array is typically shaped (N, 2) with (row, col) coordinates.
+
+    Raises:
+        MissingOptionalDependencyError: If the `fmm` extra is not installed.
     """
+    measure = extras.require("skimage.measure", extras.FMM)
+
     if np.ma.isMaskedArray(regression_field):
         # Outside-casing cells read as 0, tracing a spurious contour along the
         # wall; lift them above every iso level so only real fronts are traced.

--- a/machwave/models/grain/fmm/stl.py
+++ b/machwave/models/grain/fmm/stl.py
@@ -1,11 +1,13 @@
 from abc import ABC
 
 import numpy as np
-import trimesh
 
+import machwave.common.extras as extras
 import machwave.models.grain as grain
 import machwave.models.grain.base as grain_base
 import machwave.models.grain.fmm as grain_fmm
+
+_STL_FEATURE = "STL grain segments"
 
 
 def _resample_nearest(
@@ -40,7 +42,13 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
             length: Segment length [m].
             inhibited_surfaces: Surfaces inhibited from burning.
             grid_resolution: Grid points per axis of the cross-section.
+
+        Raises:
+            GrainGeometryError: If the segment geometry is invalid.
+            MissingOptionalDependencyError: If the `fmm` extra is not installed.
         """
+        extras.require("trimesh", extras.FMM, _STL_FEATURE)
+
         self.file_path = file_path
         self.outer_diameter = outer_diameter
         self.length = length
@@ -75,7 +83,11 @@ class FMMSTLGrainSegment(grain_fmm.FMMGrainSegment3D, ABC):
         The trimesh voxel grid does not line up with the FMM grid, so it is
         resampled onto the canonical `(normalized_length, grid_resolution, grid_resolution)`
         shape the rest of the 3D machinery expects.
+
+        Raises:
+            MissingOptionalDependencyError: If the `fmm` extra is not installed.
         """
+        trimesh = extras.require("trimesh", extras.FMM, _STL_FEATURE)
         mesh = trimesh.load_mesh(self.file_path)
         assert isinstance(mesh, trimesh.Trimesh), "Expected a single Trimesh"
         assert mesh.is_watertight, "Mesh must be watertight"


### PR DESCRIPTION
Closes #521. Stacked on #528.

`machwave/models/grain/fmm/` imported `scikit-fmm`, `scikit-image` and `trimesh` at module level and sits on the import path, because all seven non-BATES geometries subclass it. Nothing evaluated those libraries at class definition time, so moving the imports to their use sites is enough to make the class definitions importable without them.

This is the one place that needs `extras.require` rather than a module-level guard: the module has to stay importable, so the import cannot be allowed to fail at module scope.

- `FMMGrainSegment.__init__` and `FMMSTLGrainSegment.__init__` check for their dependencies up front, so constructing a geometry fails immediately rather than partway through a burn.
- `trimesh` stays inside the `fmm` extra rather than becoming a sixth one — it is needed only by `FMMSTLGrainSegment`, which is abstract with no concrete subclass in the tree. It gets its own wording, so the message is accurate about what is unavailable while the remedy stays `machwave[fmm]`.
- The fail-fast guard checks `skimage.measure`, the submodule the use sites actually call, rather than top-level `skimage`.

Two review points folded in: both constructors document the `GrainGeometryError` they already propagated from `validate()`, so their `Raises:` sections are not a partial list. And `skfmm.distance` is untyped once resolved dynamically, so assigning its result no longer narrows `padded_regression_map`, which `_compute_regression_distance` in `_3d.py` read back on the next line — it now binds the value to a local and stores it, fixing the narrowing at the source rather than annotating around it. That also retires the `# type: ignore[arg-type]` on the `dx` argument, dead for the same reason.

Verified:

- `import machwave` and `import machwave.models.grain.geometries` load none of the three; constructing a `StarGrainSegment` loads `skfmm` and `skimage`.
- With all three hidden behind a `sys.meta_path` blocker, `import machwave` still succeeds, `StarGrainSegment(...)` raises ``Non-BATES grain geometries require the `scikit-fmm` package. Install it with `pip install machwave[fmm]`.`` and an STL segment raises the trimesh equivalent.
- The `ProcessPoolExecutor` workers in `_3d.py` re-import the module in a fresh interpreter under the spawn start method, the default on macOS. Meshing iso-levels in spawned workers resolves `skimage.measure` and returns the expected areas.

Full suite passes (1197 passed, 8 skipped) as does `make check`.