### PR TITLE
Defer the plotly imports out of the Monte Carlo simulation

### DIFF
--- a/machwave/montecarlo/base.py
+++ b/machwave/montecarlo/base.py
@@ -8,7 +8,6 @@ import scipy.stats as scipy_stats
 
 import machwave.common.objects as common_objects
 import machwave.montecarlo.random as random
-import machwave.services.plots.montecarlo as plot_service
 import machwave.simulation as machwave_simulation
 
 SEARCH_TREE_DEPTH_LIMIT = 20
@@ -52,7 +51,8 @@ class MonteCarloSimulation:
     Monte Carlo driver that runs scenarios and stores their results.
 
     Stores parameters and simulation type, executes the configured number of
-    scenarios, and delegates plotting to `plot_service.py`.
+    scenarios, and delegates plotting to `machwave.services.plots.montecarlo`,
+    which needs the `plots` extra.
     """
 
     def __init__(
@@ -201,7 +201,14 @@ class MonteCarloSimulation:
         x_axes_title: str = "x",
         **plotly_kwargs,
     ) -> None:
-        """Plot a histogram of a scalar property across all results."""
+        """
+        Plot a histogram of a scalar property across all results.
+
+        Raises:
+            MissingOptionalDependencyError: If the `plots` extra is not installed.
+        """
+        import machwave.services.plots.montecarlo as plot_service
+
         plot_service.plot_histogram(
             self.results, property_name, x_axes_title, **plotly_kwargs
         )
@@ -214,7 +221,14 @@ class MonteCarloSimulation:
         kde_points: int = 200,
         **plotly_kwargs,
     ) -> None:
-        """Plot a histogram of a scalar property with a KDE overlay."""
+        """
+        Plot a histogram of a scalar property with a KDE overlay.
+
+        Raises:
+            MissingOptionalDependencyError: If the `plots` extra is not installed.
+        """
+        import machwave.services.plots.montecarlo as plot_service
+
         plot_service.plot_histogram_with_kde(
             self.results,
             property_name,
@@ -230,7 +244,14 @@ class MonteCarloSimulation:
         x_axes_title: str = "x",
         **plotly_kwargs,
     ) -> None:
-        """Plot the empirical CDF of a scalar property across all results."""
+        """
+        Plot the empirical CDF of a scalar property across all results.
+
+        Raises:
+            MissingOptionalDependencyError: If the `plots` extra is not installed.
+        """
+        import machwave.services.plots.montecarlo as plot_service
+
         plot_service.plot_cdf(
             self.results, property_name, x_axes_title, **plotly_kwargs
         )
@@ -243,7 +264,14 @@ class MonteCarloSimulation:
         title: str | None = None,
         **plotly_kwargs,
     ) -> None:
-        """Plot min and max envelopes of a time series across all results."""
+        """
+        Plot min and max envelopes of a time series across all results.
+
+        Raises:
+            MissingOptionalDependencyError: If the `plots` extra is not installed.
+        """
+        import machwave.services.plots.montecarlo as plot_service
+
         plot_service.plot_time_series_extremes(
             self.results,
             time_property,

--- a/machwave/services/plots/ballistics.py
+++ b/machwave/services/plots/ballistics.py
@@ -1,6 +1,12 @@
 import numpy as np
-import plotly.graph_objects as go
-import plotly.subplots
+
+import machwave.common.extras as extras
+
+try:
+    import plotly.graph_objects as go
+    import plotly.subplots
+except ImportError as e:  # pragma: no cover - exercised only without plotly
+    raise extras.MissingOptionalDependencyError("plotly", extras.PLOTS) from e
 
 
 def ballistics_plots(

--- a/machwave/services/plots/fmm/face_map.py
+++ b/machwave/services/plots/fmm/face_map.py
@@ -1,8 +1,13 @@
 import numpy as np
-import plotly.graph_objects as go
-from plotly.subplots import make_subplots
 
 import machwave.common.arrays as common_arrays
+import machwave.common.extras as extras
+
+try:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+except ImportError as e:  # pragma: no cover - exercised only without plotly
+    raise extras.MissingOptionalDependencyError("plotly", extras.PLOTS) from e
 
 
 def _create_plot_2d_frame(

--- a/machwave/services/plots/internal_ballistics.py
+++ b/machwave/services/plots/internal_ballistics.py
@@ -1,8 +1,14 @@
 from collections.abc import Mapping
 
 import numpy as np
-import plotly.graph_objects as go
-import plotly.subplots
+
+import machwave.common.extras as extras
+
+try:
+    import plotly.graph_objects as go
+    import plotly.subplots
+except ImportError as e:  # pragma: no cover - exercised only without plotly
+    raise extras.MissingOptionalDependencyError("plotly", extras.PLOTS) from e
 
 
 def thrust_pressure_plot(

--- a/machwave/services/plots/montecarlo.py
+++ b/machwave/services/plots/montecarlo.py
@@ -1,8 +1,14 @@
 from collections.abc import Sequence
 
 import numpy as np
-import plotly.graph_objects as go
 from scipy import stats as scipy_stats
+
+import machwave.common.extras as extras
+
+try:
+    import plotly.graph_objects as go
+except ImportError as e:  # pragma: no cover - exercised only without plotly
+    raise extras.MissingOptionalDependencyError("plotly", extras.PLOTS) from e
 
 
 def plot_histogram(


### PR DESCRIPTION
Closes #522. Stacked on #529.

The four modules under `machwave/services/plots/` imported plotly at module level, and `machwave/montecarlo/base.py` imported the Monte Carlo plot service at module level, so running a Monte Carlo simulation required plotly even when nothing was plotted.

- The plot modules guard their own imports rather than deferring to a use site. Their `go.Figure` return annotations evaluate at definition time, so a per-call guard could not work — the whole module has to fail.
- The four `MonteCarloSimulation.plot_*` methods import the service inside their bodies, so a Monte Carlo run needs plotly only if it plots.
- The class docstring pointed at a `plot_service.py` that does not exist; it now names the real module and the extra it needs.

Verified: `import machwave.montecarlo` no longer loads plotly, and importing a plot module still does. Full suite passes (1195 passed, 2 skipped) as does `make check`.

This is the last of the four deferrals. #523 moves the dependencies into the extras.