### PR TITLE
Move the heavy dependencies into optional extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,26 @@ jobs:
       - run: make install-dev
       - run: make test
 
+  test-core:
+    name: Core install
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+      # No Fortran compiler: rocketcea now arrives with the cea extra, which a
+      # core install does not pull.
+      - run: make install-dev-core
+      - run: make test-core
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,30 +64,79 @@ jobs:
           name: dist
           path: dist
 
-      - name: Install gfortran (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install gcc
-          brew_prefix=$(brew --prefix)
-          gfortran_versioned=$(ls "$brew_prefix"/bin/gfortran-* 2>/dev/null | sort -V | tail -n 1)
-          if [ -z "$gfortran_versioned" ]; then
-            echo "::error::No gfortran-* binary found in $brew_prefix/bin after brew install gcc"
-            exit 1
-          fi
-          ln -sf "$gfortran_versioned" "$brew_prefix/bin/gfortran"
-          gfortran --version
-
+      # No Fortran compiler: a core wheel install no longer builds rocketcea.
       - name: Install built wheel
         run: python -m pip install dist/*.whl
 
       - name: Smoke test
         run: |
           python -c "import machwave; print('machwave', machwave.__version__)"
-          python -c "import machwave.simulation, machwave.models, machwave.core, machwave.services, machwave.adapters"
+          python - <<'PY'
+          import sys
+
+          import machwave
+          import machwave.adapters
+          import machwave.core
+          import machwave.models
+          import machwave.models.grain.geometries
+          import machwave.models.propellants.formulations
+          import machwave.services
+          import machwave.simulation
+
+          optional = {
+              "rocketcea",
+              "CoolProp",
+              "skfmm",
+              "skimage",
+              "trimesh",
+              "plotly",
+              "rocketpy",
+          }
+          loaded = sorted(optional & set(sys.modules))
+          assert not loaded, f"core wheel import loaded optional packages: {loaded}"
+          print("core import surface clean")
+          PY
+
+  smoke-test-extras:
+    name: Smoke test built wheel with all extras
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+
+      - name: Download built distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist
+
+      - name: Install built wheel with all extras
+        run: python -m pip install "$(ls dist/*.whl)[all]"
+
+      - name: Smoke test
+        run: |
+          python -c "import machwave.services.cea, machwave.services.coolprop"
+          python -c "import machwave.services.plots.internal_ballistics"
+          python -c "import machwave.adapters.rocketpy"
+          python - <<'PY'
+          import machwave.models.grain.geometries as geometries
+
+          geometries.StarGrainSegment(
+              length=0.1,
+              outer_diameter=0.065,
+              number_of_points=5,
+              point_length=0.01,
+              point_width=0.005,
+          )
+          print("fmm geometry constructed")
+          PY
 
   publish:
     name: Publish to PyPI
-    needs: smoke-test
+    needs: [smoke-test, smoke-test-extras]
     runs-on: ubuntu-latest
     environment: publish
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
-.PHONY: install install-dev install-docs install-hooks test benchmark publish build verify-version check format-check lint typecheck format generate-umls coverage docs docs-serve docs-deploy clean
+.PHONY: install install-all install-dev install-dev-core install-docs install-hooks test test-core benchmark publish build verify-version check format-check lint typecheck format generate-umls coverage docs docs-serve docs-deploy clean
 
 install:
 	@uv sync
 
+install-all:
+	@uv sync --all-extras
+
 install-dev:
+	@uv sync --all-extras --group dev
+
+# The core environment: no extras, so the tooling is there but the optional
+# dependencies are not. Drives the test-core target.
+install-dev-core:
 	@uv sync --group dev
 
 install-docs:
-	@uv sync --group docs --group dev
+	@uv sync --all-extras --group docs --group dev
 
 install-hooks:
 	@uv run pre-commit install
@@ -25,6 +33,15 @@ verify-version:
 	echo "Version verified: $$PKG_VERSION"
 test:
 	@uv run pytest -n auto
+# Selects by path rather than by marker: testpaths collects the whole suite
+# before deselecting, and most of it cannot be imported without the extras.
+test-core:
+	@uv run pytest -n auto \
+		tests/test_optional_dependencies.py \
+		tests/test_common \
+		tests/test_core \
+		tests/test_services/test_eng.py \
+		--ignore=tests/test_core/test_two_phase_flow.py
 benchmark:
 	@uv run pytest tests/benchmarks --benchmark-only --benchmark-columns=min,median,mean,stddev,rounds
 publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,20 @@ requires-python = ">=3.11,<=3.14"
 dependencies = [
     "numpy>=2.0.0,<3.0.0",
     "fluids>=1.1.0,<2.0.0",
-    "plotly>=6.0.0,<8.0.0",
     "scipy>=1.15.2,<2.0.0",
-    "scikit-image>=0.25.2,<0.27.0",
-    "scikit-fmm==2025.6.23",
-    "trimesh>=4.6.4,<6.0.0",
-    "rocketcea>=1.2.1,<2.0.0",
-    "coolprop>=6.7.0,<9.0.0",
 ]
 
 [project.optional-dependencies]
-rocketpy = ["rocketpy>=1.0.0,<2.0.0"]
+cea = ["rocketcea>=1.2.1,<2.0.0"]
+liquid = ["coolprop>=6.7.0,<9.0.0"]
+fmm = [
+    "scikit-fmm==2025.6.23",
+    "scikit-image>=0.25.2,<0.27.0",
+    "trimesh>=4.6.4,<6.0.0",
+]
+plots = ["plotly>=6.0.0,<8.0.0"]
+rocketpy = ["rocketpy>=1.11.0,<2.0.0"]
+all = ["machwave[cea,liquid,fmm,plots,rocketpy]"]
 
 [dependency-groups]
 dev = [
@@ -38,7 +41,6 @@ dev = [
     "pytest-benchmark>=5.0.0,<6.0.0",
     "pytest-cov>=6.2.1,<8.0.0",
     "polyfactory>=3.1.0,<4.0.0",
-    "rocketpy>=1.11.0,<2.0.0",
     "pre-commit>=4.0.0,<5.0.0",
     "pytest-xdist>=3.6.0,<4.0.0",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ python_files = test_*.py
 python_functions = test_*
 testpaths = tests
 addopts = --benchmark-skip
+markers =
+    core: exercises Machwave with only its core dependencies installed.

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,201 @@
+import importlib.util
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import machwave.common.extras as extras
+
+pytestmark = pytest.mark.core
+
+OPTIONAL_PACKAGES = (
+    "rocketcea",
+    "CoolProp",
+    "skfmm",
+    "skimage",
+    "trimesh",
+    "plotly",
+    "rocketpy",
+)
+
+PUBLIC_IMPORT_SURFACE = """
+    import machwave
+    import machwave.adapters
+    import machwave.core
+    import machwave.models
+    import machwave.models.feed_systems
+    import machwave.models.grain
+    import machwave.models.grain.geometries
+    import machwave.models.motors
+    import machwave.models.nozzle_losses
+    import machwave.models.propellants
+    import machwave.models.propellants.formulations
+    import machwave.models.thrust_chamber
+    import machwave.montecarlo
+    import machwave.services
+    import machwave.simulation
+
+    assert machwave.__version__
+"""
+
+BATES_SIMULATION = """
+    import machwave.models.grain as grain_models
+    import machwave.models.motors as motors_models
+    import machwave.models.nozzle_losses as nozzle_losses
+    import machwave.models.propellants.formulations as formulations
+    import machwave.models.thrust_chamber as thrust_chamber_models
+    import machwave.simulation as simulation
+
+    grain = grain_models.Grain(spacing=10e-3)
+    for _ in range(4):
+        grain.add_segment(
+            grain_models.geometries.BatesSegment(
+                outer_diameter=41e-3, core_diameter=15e-3, length=67.5e-3
+            )
+        )
+
+    motor = motors_models.SolidMotor(
+        grain=grain,
+        propellant=formulations.solid.KNDX,
+        thrust_chamber=thrust_chamber_models.SolidMotorThrustChamber(
+            nozzle=thrust_chamber_models.Nozzle(
+                inlet_diameter=43e-3,
+                throat_diameter=9.5e-3,
+                divergent_angle=12,
+                convergent_angle=40,
+                expansion_ratio=8,
+            ),
+            combustion_chamber=thrust_chamber_models.CombustionChamber(
+                casing_inner_diameter=44.5e-3,
+                casing_outer_diameter=50.8e-3,
+                thermal_liner_thickness=1e-3,
+                internal_length=grain.total_length + 10e-3,
+            ),
+            nozzle_exit_to_grain_port_distance=0.01,
+        ),
+        combustion_efficiency=0.95,
+        nozzle_loss_model=nozzle_losses.presets.spp1975_solid_loss_model(
+            other_losses=0.12
+        ),
+    )
+
+    result = simulation.InternalBallisticsSimulation(
+        motor=motor,
+        params=simulation.InternalBallisticsSimulationParams(
+            d_t=0.01, igniter_pressure=1e6, external_pressure=1e5
+        ),
+    ).run()
+
+    assert result.thrust.max() > 0
+"""
+
+
+IMPORT_CHECK = """
+    import sys
+
+    loaded = sorted(set(OPTIONAL_PACKAGES) & set(sys.modules))
+    assert not loaded, f"core path loaded optional packages: {loaded}"
+"""
+
+
+def assert_no_optional_package_loaded(body: str) -> None:
+    """
+    Run a snippet in a fresh interpreter, asserting it loads no optional package.
+
+    A subprocess is what makes this meaningful in an environment where the
+    optional packages are installed: it proves nothing on the core path imports
+    them, rather than only that the core path works when they are absent.
+    """
+    script = "\n".join(
+        [
+            f"OPTIONAL_PACKAGES = {OPTIONAL_PACKAGES!r}",
+            textwrap.dedent(body),
+            textwrap.dedent(IMPORT_CHECK),
+        ]
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, check=False
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_public_import_surface_loads_no_optional_package():
+    assert_no_optional_package_loaded(PUBLIC_IMPORT_SURFACE)
+
+
+def test_bates_solid_simulation_runs_on_the_core_dependencies():
+    assert_no_optional_package_loaded(BATES_SIMULATION)
+
+
+def is_installed(package: str) -> bool:
+    """Whether a package can be imported in this environment."""
+    return importlib.util.find_spec(package) is not None
+
+
+def skip_if_installed(package: str):
+    """Skip when the package is installed, since the guard cannot fire then."""
+    return pytest.mark.skipif(
+        is_installed(package), reason=f"{package} is installed; the guard cannot fire"
+    )
+
+
+@skip_if_installed("skfmm")
+def test_fmm_geometry_construction_names_the_fmm_extra():
+    import machwave.models.grain.geometries as geometries
+
+    with pytest.raises(ImportError, match=rf"machwave\[{extras.FMM}\]"):
+        geometries.StarGrainSegment(
+            length=0.1,
+            outer_diameter=0.065,
+            number_of_points=5,
+            point_length=0.01,
+            point_width=0.005,
+        )
+
+
+@skip_if_installed("trimesh")
+def test_stl_grain_segment_names_the_fmm_extra():
+    import machwave.models.grain.fmm as grain_fmm
+
+    class StlSegment(grain_fmm.FMMSTLGrainSegment):
+        def get_web_thickness(self) -> float:
+            return 0.0
+
+    with pytest.raises(ImportError, match=rf"machwave\[{extras.FMM}\]"):
+        StlSegment(file_path="grain.stl", outer_diameter=0.065, length=0.1)
+
+
+@skip_if_installed("CoolProp")
+def test_tank_construction_names_the_liquid_extra():
+    import machwave.models.feed_systems.tank as tank_models
+
+    with pytest.raises(ImportError, match=rf"machwave\[{extras.LIQUID}\]"):
+        tank_models.Tank(
+            fluid_name="N2O",
+            volume=0.01,
+            temperature=293.15,
+            initial_fluid_mass=5.0,
+        )
+
+
+@skip_if_installed("rocketcea")
+def test_biliquid_evaluation_names_the_cea_extra():
+    import machwave.models.propellants.formulations as formulations
+
+    with pytest.raises(ImportError, match=rf"machwave\[{extras.CEA}\]"):
+        formulations.biliquid.LOX_LH2_6_0.evaluate(chamber_pressure=6e6)
+
+
+@skip_if_installed("plotly")
+def test_plot_module_import_names_the_plots_extra():
+    with pytest.raises(ImportError, match=rf"machwave\[{extras.PLOTS}\]"):
+        import machwave.services.plots.internal_ballistics  # noqa: F401
+
+
+@skip_if_installed("rocketpy")
+def test_rocketpy_adapter_import_names_the_rocketpy_extra():
+    with pytest.raises(ImportError, match=rf"machwave\[{extras.ROCKETPY}\]"):
+        import machwave.adapters.rocketpy  # noqa: F401

--- a/uv.lock
+++ b/uv.lock
@@ -783,18 +783,35 @@ wheels = [
 name = "machwave"
 source = { editable = "." }
 dependencies = [
-    { name = "coolprop" },
     { name = "fluids" },
     { name = "numpy" },
-    { name = "plotly" },
-    { name = "rocketcea" },
-    { name = "scikit-fmm" },
-    { name = "scikit-image" },
     { name = "scipy" },
-    { name = "trimesh" },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "coolprop" },
+    { name = "plotly" },
+    { name = "rocketcea" },
+    { name = "rocketpy" },
+    { name = "scikit-fmm" },
+    { name = "scikit-image" },
+    { name = "trimesh" },
+]
+cea = [
+    { name = "rocketcea" },
+]
+fmm = [
+    { name = "scikit-fmm" },
+    { name = "scikit-image" },
+    { name = "trimesh" },
+]
+liquid = [
+    { name = "coolprop" },
+]
+plots = [
+    { name = "plotly" },
+]
 rocketpy = [
     { name = "rocketpy" },
 ]
@@ -810,7 +827,6 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
-    { name = "rocketpy" },
     { name = "ruff" },
 ]
 docs = [
@@ -821,18 +837,25 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coolprop", specifier = ">=6.7.0,<9.0.0" },
+    { name = "coolprop", marker = "extra == 'all'", specifier = ">=6.7.0,<9.0.0" },
+    { name = "coolprop", marker = "extra == 'liquid'", specifier = ">=6.7.0,<9.0.0" },
     { name = "fluids", specifier = ">=1.1.0,<2.0.0" },
     { name = "numpy", specifier = ">=2.0.0,<3.0.0" },
-    { name = "plotly", specifier = ">=6.0.0,<8.0.0" },
-    { name = "rocketcea", specifier = ">=1.2.1,<2.0.0" },
-    { name = "rocketpy", marker = "extra == 'rocketpy'", specifier = ">=1.0.0,<2.0.0" },
-    { name = "scikit-fmm", specifier = "==2025.6.23" },
-    { name = "scikit-image", specifier = ">=0.25.2,<0.27.0" },
+    { name = "plotly", marker = "extra == 'all'", specifier = ">=6.0.0,<8.0.0" },
+    { name = "plotly", marker = "extra == 'plots'", specifier = ">=6.0.0,<8.0.0" },
+    { name = "rocketcea", marker = "extra == 'all'", specifier = ">=1.2.1,<2.0.0" },
+    { name = "rocketcea", marker = "extra == 'cea'", specifier = ">=1.2.1,<2.0.0" },
+    { name = "rocketpy", marker = "extra == 'all'", specifier = ">=1.11.0,<2.0.0" },
+    { name = "rocketpy", marker = "extra == 'rocketpy'", specifier = ">=1.11.0,<2.0.0" },
+    { name = "scikit-fmm", marker = "extra == 'all'", specifier = "==2025.6.23" },
+    { name = "scikit-fmm", marker = "extra == 'fmm'", specifier = "==2025.6.23" },
+    { name = "scikit-image", marker = "extra == 'all'", specifier = ">=0.25.2,<0.27.0" },
+    { name = "scikit-image", marker = "extra == 'fmm'", specifier = ">=0.25.2,<0.27.0" },
     { name = "scipy", specifier = ">=1.15.2,<2.0.0" },
-    { name = "trimesh", specifier = ">=4.6.4,<6.0.0" },
+    { name = "trimesh", marker = "extra == 'all'", specifier = ">=4.6.4,<6.0.0" },
+    { name = "trimesh", marker = "extra == 'fmm'", specifier = ">=4.6.4,<6.0.0" },
 ]
-provides-extras = ["rocketpy"]
+provides-extras = ["all", "cea", "fmm", "liquid", "plots", "rocketpy"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -845,7 +868,6 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.0.0,<6.0.0" },
     { name = "pytest-cov", specifier = ">=6.2.1,<8.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.0,<4.0.0" },
-    { name = "rocketpy", specifier = ">=1.11.0,<2.0.0" },
     { name = "ruff" },
 ]
 docs = [


### PR DESCRIPTION
Closes #523. Stacked on #530. This is the commit where behaviour changes, so it is the one to revert if anything goes wrong.

`rocketcea`, `coolprop`, `scikit-fmm`, `scikit-image`, `trimesh` and `plotly` move out of `[project] dependencies` into `cea`, `liquid`, `fmm` and `plots`, with an aggregate `all`. The core install is numpy, scipy and fluids.

- `rocketpy` loses its duplicate entry in the dev group, and its floor rises from `>=1.0.0` to the `>=1.11.0` that group already pinned, so a core environment is genuinely core and CI tests the version users get.
- `install-dev` gains `--all-extras`, which is what keeps `make typecheck` green: pyright runs in default standard mode where `reportMissingImports` is an error, and it analyses `TYPE_CHECKING` branches unconditionally. `install-dev-core` builds the core environment.
- `test-core` selects by path rather than by the new `core` marker. `testpaths = tests` means `-m core` still collects the whole suite before deselecting, and `tests/test_models/conftest.py`, `tests/factories/` and others raise at collection time without the extras, which fails the run regardless of deselection.

`tests/test_optional_dependencies.py` covers two things:

- Subprocess assertions that importing the public surface, and running a BATES simulation, load none of the seven optional packages. These run in **both** legs — they catch a re-added module-level import in the fully installed matrix, so the core leg is not the only defence.
- One guard test per extra, skipped when the package is present, asserting the error names the right install command. They match on the constants in `machwave/common/extras.py`, so renaming an extra never touches the tests.

## Verification

In a real core environment (`make install-dev-core`, all seven optional packages confirmed absent):

- `make test-core` — 184 passed, including all 8 optional-dependency tests, with the six guards running rather than skipping.
- `examples/nero_motor.py` with only its plot call removed runs end to end and reports numbers identical to a full install: 7.357/6.620 MPa, 678.145/607.830 N peak/average thrust, 668.254 N-s total impulse, 118.148 s specific impulse.

In the full environment: 1197 passed, 8 skipped; `make check` clean; `make docs-deploy` builds strict.

CI gains a `test-core` job across the three runners with no Fortran compiler step, since rocketcea now arrives with the `cea` extra. In `publish.yml` the macOS gfortran step is dropped from `smoke-test`, whose script now asserts the core wheel's import surface pulls no optional package, and a new `smoke-test-extras` job installs the wheel with `[all]` and imports each gated module. Both workflows were checked by parsing the YAML, running `bash -n` over the smoke-test scripts, and executing the core smoke test verbatim.