### PR TITLE
Document the optional extras and scope the gfortran prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,40 @@ Install Machwave using pip:
 pip install machwave
 ```
 
-#### macOS prerequisite: gfortran
+The core install depends only on NumPy, SciPy and fluids. It runs a complete solid
+rocket motor simulation with BATES grains, any of the eight bundled solid propellant
+formulations and the full Solid Performance Program 1975 nozzle loss set. Those
+formulations carry pre-computed thermochemical properties, so no thermochemistry
+solver is needed to burn them.
 
-Machwave depends on [rocketcea](https://pypi.org/project/RocketCEA/), which does
-not publish macOS wheels on PyPI. On macOS, pip therefore builds rocketcea from
-source and needs a Fortran compiler. Homebrew's `gcc` formula installs only
-versioned binaries (e.g. `gfortran-15`), so an unversioned `gfortran` symlink
-must be added to `PATH` before `pip install machwave`:
+Everything heavier is an optional extra:
+
+| Extra | Unlocks |
+| --- | --- |
+| `cea` | Thermochemistry computed from propellant composition, needed for biliquid engines and for custom solid mixtures |
+| `liquid` | Propellant tanks and the injector's homogeneous-equilibrium mass flux |
+| `fmm` | Every grain geometry other than BATES, including grains defined by an STL mesh |
+| `plots` | The built-in figures and the Monte Carlo plots |
+| `rocketpy` | The RocketPy adapter for trajectory simulation |
+| `all` | All of the above |
+
+Install one or several by name, for example:
+
+```bash
+pip install machwave[fmm,plots]
+```
+
+Using a feature without its extra raises an `ImportError` naming the install command
+that provides it.
+
+#### macOS prerequisite for the `cea` extra: gfortran
+
+Only needed if you install the `cea` extra, directly or through `all`.
+[rocketcea](https://pypi.org/project/RocketCEA/) does not publish macOS wheels on
+PyPI. On macOS, pip therefore builds rocketcea from source and needs a Fortran
+compiler. Homebrew's `gcc` formula installs only versioned binaries (e.g.
+`gfortran-15`), so an unversioned `gfortran` symlink must be added to `PATH`
+beforehand:
 
 ```bash
 brew install gcc
@@ -67,8 +94,12 @@ Clone the repository and install dependencies:
 ```bash
 git clone https://github.com/felipebogaertsm/machwave.git
 cd machwave
-make install
+make install-dev
 ```
+
+`make install-dev` installs every extra alongside the development tooling, which is
+what the test suite and the type checker need. `make install-dev-core` installs the
+tooling without the extras, the environment `make test-core` runs against.
 
 #### Publishing a New Release
 

--- a/docs/api/models/feed_systems.md
+++ b/docs/api/models/feed_systems.md
@@ -9,7 +9,7 @@ organised around three concerns:
 | Contract | `feed_systems.base` | The abstract [`FeedSystem`][machwave.models.feed_systems.base.FeedSystem] interface every cycle must satisfy. |
 | Cycle implementations | [`feed_systems.cycles`](feed_systems/cycles.md) | One module per cycle topology (pressure-fed today; electric-pump, gas-generator, expander, staged-combustion to follow). |
 | Shared component descriptions | [`feed_systems.components`](feed_systems/components.md) | Static descriptions of pumps, turbines, gas generators, regenerative jackets, plus a tabulated-curve helper that cycle implementations consume. |
-| Tank thermodynamics | [`feed_systems.tank`](feed_systems/tank.md) | Two-phase tank model backed by CoolProp. |
+| Tank thermodynamics | [`feed_systems.tank`](feed_systems/tank.md) | Two-phase tank model backed by CoolProp (`liquid` extra). |
 | Propellant lines | `feed_systems.lines` | The [`PropellantLine`][machwave.models.feed_systems.lines.PropellantLine] a feed system delivers — its name, its role, and the tank it draws from — and the [`LineState`][machwave.models.feed_systems.lines.LineState] the integrator carries for it. |
 
 ## The `FeedSystem` contract

--- a/docs/api/models/feed_systems/tank.md
+++ b/docs/api/models/feed_systems/tank.md
@@ -1,5 +1,8 @@
 # models.feed_systems.tank
 
+!!! note "Requires the `liquid` extra"
+    `pip install machwave[liquid]`. Constructing a `Tank` without it raises an `ImportError` naming that command.
+
 Stateless two-phase propellant tank model backed by CoolProp. The `Tank` carries no propellant state: pressure and density are pure functions of the state supplied by the caller. `get_pressure(fluid_mass)` returns the tank pressure from two-phase equilibrium (saturation pressure while liquid is present, single-phase vapour from the real-gas equation of state otherwise), and `get_density(fluid_mass)` the density at current conditions.
 
 A tank is isothermal by default: its temperature is held where it was loaded, so a self-pressurizing tank holds its saturation pressure flat for as long as any liquid remains. Passing `isothermal=False` runs an energy balance instead. The tank's internal energy then becomes a second state variable the integrator carries beside the mass, starting from `initial_internal_energy` and falling by the enthalpy of whatever drains out (`get_outflow_specific_enthalpy`), so the temperature and the saturation pressure decay over the burn. Every query on such a tank takes that internal energy alongside the mass, and says so when it is missing.

--- a/docs/api/models/grain/fmm.md
+++ b/docs/api/models/grain/fmm.md
@@ -2,6 +2,9 @@
 
 Fast Marching Method (FMM) base classes for grain geometries whose cross-section cannot be described analytically. The burning surface at any web distance is read off a single distance map of the initial port, solved with scikit-fmm.
 
+!!! note "Requires the `fmm` extra"
+    `pip install machwave[fmm]`. Constructing any FMM segment without it raises an `ImportError` naming that command. `BatesSegment` is analytical and needs no extra.
+
 - `FMMGrainSegment` — Shared regression logic: builds the distance map and derives web thickness, the regressed face map, and port and burn area from it.
 - `FMMGrainSegment2D` — Constant cross-section geometries (Star, D-grain, wagon-wheel, multi-port, rod-and-tube). Burn area is the core perimeter (a single contour of the distance map) times the grain length, plus any exposed end faces.
 - `FMMGrainSegment3D` — Axially varying cross-section geometries (Conical, Finocyl). The port is a stack of axial slices through a 3D distance map; burn area is the marching-cubes area of the regressing iso-surface, and port area is read from a chosen slice.

--- a/docs/api/models/grain/geometries.md
+++ b/docs/api/models/grain/geometries.md
@@ -2,6 +2,9 @@
 
 Concrete grain segment geometries, both analytical and FMM-based.
 
+!!! note "FMM-based geometries require the `fmm` extra"
+    `pip install machwave[fmm]`. Every geometry below except `BatesSegment` is FMM-based; constructing one without the extra raises an `ImportError` naming that command.
+
 **2D (constant cross-section):**
 
 - `BatesSegment` — Cylindrical grain with an axial core, the most common amateur geometry (analytical).
@@ -13,7 +16,7 @@ Concrete grain segment geometries, both analytical and FMM-based.
 
 **3D (varying cross-section):**
 
-- `ConicalGrainSegment` — Linearly tapered core from upper to lower diameter.
+- `ConicalGrainSegment` — Linearly tapered core from upper to lower diameter (FMM-based).
 - `FinocylGrainSegment` — Central circular bore with radial fins over a partial axial section (FMM-based).
 
 All segments implement the `GrainSegment` interface and can be mixed within a single `Grain`.

--- a/docs/api/models/propellants.md
+++ b/docs/api/models/propellants.md
@@ -2,6 +2,9 @@
 
 Propellant definition and thermochemical evaluation. A propellant is built from `PropellantComponent` instances (each with a chemical formula, density, enthalpy, and role), then evaluated at operating conditions via NASA CEA to obtain γ, molecular weight, adiabatic flame temperature, Isp, and condensed-phase fractions.
 
+!!! note "Composition-derived evaluation requires the `cea` extra"
+    The bundled solid formulations carry pre-computed thermochemical properties and evaluate without it. Deriving properties from composition — every biliquid propellant, and any solid built without a `properties` block — needs `pip install machwave[cea]`.
+
 Submodules:
 
 - [categories](propellants/categories.md) — `SolidPropellant` (with St. Robert’s burn rate law) and `BiliquidPropellant` (with O/F ratio)

--- a/docs/api/models/propellants/categories.md
+++ b/docs/api/models/propellants/categories.md
@@ -5,6 +5,6 @@ Propellant type classes.
 - `SolidPropellant` — Defined by component mass fractions, pre-computed or CEA-evaluated thermochemical properties, and a `burn_rate_map` encoding St. Robert’s law coefficients ($r = a \cdot P_0^n$) across pressure ranges. Call `get_burn_rate(P_0)` to obtain instantaneous regression rate.
 - `BiliquidPropellant` — Defined by exactly two components (oxidizer + fuel) and an O/F mass ratio. Thermochemical properties are evaluated at the specified O/F.
 
-Both extend the `Propellant` base class and implement `evaluate(chamber_pressure, expansion_ratio, mixture_ratio=None)` to return a `ThermochemicalProperties` dataclass. The optional `mixture_ratio` overrides the propellant's stored ratio per-call — `BiliquidEngineState` uses this to feed the live $\dot{m}_{ox} / \dot{m}_{fuel}$ each step.
+Both extend the `Propellant` base class and implement `evaluate(chamber_pressure, expansion_ratio, mixture_ratio=None)` to return a `ThermochemicalProperties` dataclass. A `SolidPropellant` carrying pre-computed properties returns them directly and needs no thermochemistry solver; every other path evaluates through CEA and needs the `cea` extra. The optional `mixture_ratio` overrides the propellant's stored ratio per-call — `BiliquidEngineState` uses this to feed the live $\dot{m}_{ox} / \dot{m}_{fuel}$ each step.
 
 ::: machwave.models.propellants.categories

--- a/docs/api/montecarlo.md
+++ b/docs/api/montecarlo.md
@@ -4,4 +4,7 @@ Uncertainty and sensitivity analysis via Monte Carlo simulation. Wrap any motor 
 
 Useful for characterizing thrust variability, pressure envelope, and impulse confidence intervals due to manufacturing tolerances and propellant batch variation.
 
+!!! note "Plotting requires the `plots` extra"
+    Running a Monte Carlo simulation and reading its aggregates needs no extra. Only `plot_histogram`, `plot_histogram_with_kde`, `plot_cdf` and `plot_time_series_extremes` do: `pip install machwave[plots]`.
+
 ::: machwave.montecarlo

--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -2,9 +2,9 @@
 
 External service integrations, I/O helpers, and visualization tools.
 
-- **CEA** — Wrapper around NASA CEA (via RocketCEA) for thermochemical equilibrium calculations: adiabatic flame temperature, exhaust molecular weight, γ, Isp (frozen and shifting), and condensed-phase species fractions.
+- **CEA** — Wrapper around NASA CEA (via RocketCEA) for thermochemical equilibrium calculations: adiabatic flame temperature, exhaust molecular weight, γ, Isp (frozen and shifting), and condensed-phase species fractions (`cea` extra).
 - **eng** — `.eng` thrust-curve file generation for OpenRocket, RASAero, and other flight simulators.
-- **plots** — Plotly-based interactive charts for internal ballistics results, Monte Carlo histograms/CDFs, and trajectory profiles.
+- **plots** — Plotly-based interactive charts for internal ballistics results, Monte Carlo histograms/CDFs, and trajectory profiles (`plots` extra).
 
 See [eng](services/eng.md) for the `.eng` writer and [plots](services/plots.md) for the visualization API.
 

--- a/docs/api/services/plots.md
+++ b/docs/api/services/plots.md
@@ -2,6 +2,9 @@
 
 Interactive Plotly-based visualization for simulation results.
 
+!!! note "Requires the `plots` extra"
+    `pip install machwave[plots]`. Importing any module below without it raises an `ImportError` naming that command.
+
 - **Internal ballistics** — Dual-axis thrust vs. chamber pressure plot, per-segment mass flux over time.
 - **Biliquid engine profiles** — Tank pressure and propellant mass traces for oxidizer and fuel.
 - **Ballistics** — Altitude, velocity, and acceleration subplots for trajectory analysis.

--- a/docs/explanations/grain_regression.md
+++ b/docs/explanations/grain_regression.md
@@ -116,7 +116,7 @@ By default only the outer surface is inhibited.
 ![masked face](../assets/explanations/grain_regression/masked_face.svg)
 
 **Compute the regression map: [`get_regression_map()`][machwave.models.grain.fmm.base.FMMGrainSegment.get_regression_map].**
-Now the fast marching method runs. `skfmm.distance` fills every propellant cell with its distance from the burning surface, as a fraction of the grain radius. The map's largest value is the web thickness ([`get_web_thickness()`][machwave.models.grain.fmm.base.FMMGrainSegment.get_web_thickness]).
+Now the fast marching method runs. `skfmm.distance` fills every propellant cell with its distance from the burning surface, as a fraction of the grain radius. `skfmm` and the `skimage` used further down both arrive with the `fmm` extra (`pip install machwave[fmm]`). The map's largest value is the web thickness ([`get_web_thickness()`][machwave.models.grain.fmm.base.FMMGrainSegment.get_web_thickness]).
 
 ```
   ·   ·   ·   ·   ·   · 0.5   ·   ·   ·   ·   ·   ·

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,15 @@
 Machwave is an open source Python library for chemical rocket propulsion simulation.
 Here is what it is capable of:
 
-- **Propellant modeling** with NASA CEA integration and pre-defined formulations
-- **Grain regression analysis** with FMM for 2D and 3D geometries
+- **Propellant modeling** with pre-defined formulations, and NASA CEA integration
+  for composition-derived thermochemistry (`cea` extra)
+- **Grain regression analysis** with FMM for 2D and 3D geometries (`fmm` extra)
 - **Rocket motor and engine simulation** for the following categories:
     - Solid Rocket Motors
-    - *Bi-propellant Liquid Rocket Engines (in development 🔧)*
+    - *Bi-propellant Liquid Rocket Engines (in development 🔧)* (`cea` and `liquid` extras)
     - *Hybrid Rocket Engines (coming soon 🗓️)*
 - **Monte Carlo simulation** for all of the motors/engines above
-- **Integration with RocketPy** for trajectory simulation and analysis
+- **Integration with RocketPy** for trajectory simulation and analysis (`rocketpy` extra)
 
 ## Installation
 
@@ -23,11 +24,33 @@ Machwave requires **Python 3.11 – 3.14**.
 pip install machwave
 ```
 
-or, for the full integration with RocketPy:
+The core install depends only on NumPy, SciPy and fluids, and runs a complete solid
+rocket motor simulation with BATES grains, any of the eight bundled solid propellant
+formulations and the full Solid Performance Program 1975 nozzle loss set. Those
+formulations carry pre-computed thermochemical properties, so no thermochemistry
+solver is needed to burn them.
+
+Everything heavier is an optional extra:
+
+| Extra | Unlocks |
+| --- | --- |
+| `cea` | Thermochemistry computed from propellant composition, needed for biliquid engines and for custom solid mixtures |
+| `liquid` | Propellant tanks and the injector's homogeneous-equilibrium mass flux |
+| `fmm` | Every grain geometry other than BATES, including grains defined by an STL mesh |
+| `plots` | The built-in figures and the Monte Carlo plots |
+| `rocketpy` | The RocketPy adapter for trajectory simulation |
+| `all` | All of the above |
+
+Install one or several by name, for example:
 
 ```bash
-pip install machwave[rocketpy]
+pip install machwave[fmm,plots]
 ```
+
+Using a feature without its extra raises an `ImportError` naming the install command
+that provides it. On macOS the `cea` extra needs a Fortran compiler; see the
+[README](https://github.com/felipebogaertsm/machwave#macos-prerequisite-for-the-cea-extra-gfortran)
+for the one-time setup.
 
 ## Quick Start
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,6 +111,9 @@ result.report()
 ib_plots.thrust_pressure_plot(result.time, result.thrust, result.chamber_pressure).show()
 ```
 
+!!! note "The plot needs the `plots` extra"
+    Everything up to here runs on the core install. Only the plot needs `pip install machwave[plots]`; `result.report()` on its own does not.
+
 ```text
 INTERNAL BALLISTICS SIMULATION RESULTS
 


### PR DESCRIPTION
Closes #524. Stacked on #531. Last of the stack for #174.

`README.md` presented the macOS gfortran prerequisite as unconditional. It applies only to the `cea` extra now, which is the biggest user-facing part of the split and was the most misleading page.

- `README.md` and `docs/index.md` lead with what the core install can do — a complete solid motor simulation with BATES grains, any of the eight bundled formulations and the full Solid Performance Program 1975 loss set — then table the six extras. The gfortran block moves under a heading scoped to `cea` and opens by saying it is only needed there.
- The README's contributor setup said `make install`, which now gives a core install. It says `make install-dev`, and explains what `make install-dev-core` is for.
- Every reference page that already named a heavy dependency in prose gains a one-line admonition: `grain/fmm.md`, `grain/geometries.md`, `feed_systems/tank.md`, `feed_systems.md`, `services/plots.md`, `services.md`, `montecarlo.md`, `propellants.md`, `propellants/categories.md` and `explanations/grain_regression.md`.
- `docs/quickstart.md` marks the plotting step as the first one needing an extra, and notes `result.report()` works without it.
- The `montecarlo.md` note is careful about the boundary: running a Monte Carlo simulation and reading its aggregates needs no extra, only the four `plot_*` methods do.
- `ConicalGrainSegment` was the one FMM-based geometry missing its `(FMM-based)` marker in the geometries page.

Verified: `make docs-deploy` builds strict, and all six admonitions render in the built site. Full suite passes (1197 passed, 8 skipped) as does `make check`.