### PR TITLE
Link reference pages to their explanations and correct the components page

### DIFF
--- a/docs/api/core/mass_balance.md
+++ b/docs/api/core/mass_balance.md
@@ -6,4 +6,7 @@ The caller supplies \(\dot{m}_{in}\) (propellant regression for a solid motor,
 summed injector flows for a biliquid engine) as a callable evaluated at each
 Runge-Kutta stage pressure.
 
+The control-volume balance behind it is derived in
+[Mass Balance](../../explanations/mass_balance.md).
+
 ::: machwave.core.mass_balance

--- a/docs/api/models/feed_systems/components.md
+++ b/docs/api/models/feed_systems/components.md
@@ -1,6 +1,6 @@
 # models.feed_systems.components
 
-Static, immutable descriptions of the physical components a feed-system cycle is built from. The classes in this sub-package do not contain integration state and never mutate during a simulation. Cycle implementations in [`machwave.models.feed_systems.cycles`](cycles.md) read these specifications and combine them with the live tank state and chamber conditions to compute mass flow, head rise, and shaft power.
+Static, immutable descriptions of the physical components a feed-system cycle is built from. The classes in this sub-package do not contain integration state and never mutate during a simulation. Cycle implementations in [`machwave.models.feed_systems.cycles`](cycles.md) combine these specifications with the live tank state and chamber conditions to compute mass flow, head rise, and shaft power. The cycles that do so — electric-pump, gas-generator, expander and staged-combustion — are not implemented yet: the two pressure-fed cycles available today read none of these specifications.
 
 - `PumpSpec` — A propellant pump at its design point: isentropic efficiency, pressure rise, volumetric flow, and shaft speed.
 - `TurbineSpec` — A turbine at its design point: isentropic efficiency, pressure ratio, inlet temperature, and mass flow.

--- a/docs/api/models/grain/fmm.md
+++ b/docs/api/models/grain/fmm.md
@@ -7,6 +7,6 @@ Fast Marching Method (FMM) base classes for grain geometries whose cross-section
 - `FMMGrainSegment3D` — Axially varying cross-section geometries (Conical, Finocyl). The port is a stack of axial slices through a 3D distance map; burn area is the marching-cubes area of the regressing iso-surface, and port area is read from a chosen slice.
 - `FMMSTLGrainSegment` — Arbitrary grain geometry imported from an STL mesh file.
 
-Used internally by the concrete geometry classes in [geometries](geometries.md).
+Used internally by the concrete geometry classes in [geometries](geometries.md). The regression scheme these classes share is derived in [Grain Regression](../../../explanations/grain_regression.md).
 
 ::: machwave.models.grain.fmm

--- a/machwave/core/interpolation.py
+++ b/machwave/core/interpolation.py
@@ -5,7 +5,13 @@ from scipy.interpolate import CubicSpline
 
 
 class BoundedCubicSpline:
-    """Cubic spline interpolant that does not extrapolate outside its domain."""
+    """
+    Cubic spline interpolant that does not extrapolate outside its domain.
+
+    The cubic fit keeps derivatives smooth for the solvers that consume these
+    curves. Inputs outside the knot range raise instead of returning fabricated
+    values.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
Finishes the reference-page cleanup started in #515. That pull request was purely subtractive: it cut the rationale out of ten pages under `docs/api/` but wrote no explanation pages and added no links into that quadrant. This adds the links whose targets already exist, lands the one item the issue routed to a docstring, and fixes the second of the two defects the issue recorded.

**Links added**

- `core/mass_balance.md` → the Mass Balance explanation, which carries the control-volume derivation and the Seidel citation that was cut from the page.
- `models/grain/fmm.md` → the Grain Regression explanation, which covers the comparison against re-meshing at every regression step.

**Moved into the code**

The smooth-derivative and no-extrapolation reasoning cut from `core/interpolation.md` now sits in the `BoundedCubicSpline` docstring, as the issue asked — no explanation page earns a section for one utility class.

**Defect fixed**

`models/feed_systems/components.md` stated that the cycle implementations read these specifications. None do. All four specs appear only in their own unit tests, and the only cycles implemented are `SingleLinePressureFedFeedSystem` and `StackedTankPressureFedFeedSystem`, neither of which touches them. The page now names the cycles that would consume them — electric-pump, gas-generator, expander, staged-combustion (#269, #272, #273, #274) — and states that those are not implemented yet.

**Out of scope**

Writing the explanation pages that the remaining seven reference pages need: feed systems, components, cycles, tank, the thrust chamber center-of-gravity frames, simulation, and solvers. Those are being written by hand later. The prose is recoverable from e7c45ee. #504 tracks the feed-system half; there is no issue yet for the simulation-loop page that `simulation.md` and `core/solvers.md` feed.

`mkdocs build --strict` passes and both new links resolve in the rendered HTML.

Closes #514.
