### PR TITLE
Reword the documentation home page and correct the extras table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,14 +22,14 @@ Machwave's main capabilities are:
 pip install machwave
 ```
 
-The core install can run a complete solid rocket motor simulation with BATES grains, with any of the preset solid propellant formulations.
+The core install can run a complete SRM simulation with BATES grains, with any of the preset solid propellant formulations.
 Additional capabilities such as LRE simulation, FMM grain regression, or RocketPy trajectory simulation can be unlocked by installing the extra bundled packages:
 
 | Extra | Unlocks |
 | --- | --- |
 | `cea` | Thermochemistry computed from propellant composition, i.e. biliquid engines, custom solid formulations |
-| `liquid` | Propellant tanks and the injector's homogeneous-equilibrium mass flux |
-| `fmm` | Every grain geometry other than BATES, including grains defined by an STL mesh |
+| `liquid` | Fluid state models for propellant tanks and injectors |
+| `fmm` | Fast marching method for complex grain regression analysis |
 | `plots` | The built-in figures and the Monte Carlo plots |
 | `rocketpy` | The RocketPy adapter for trajectory simulation |
 | `all` | All of the above |
@@ -39,11 +39,6 @@ Install one or several by name, for example:
 ```bash
 pip install machwave[fmm,plots]
 ```
-
-Using a feature without its extra raises an `ImportError` naming the install command
-that provides it. On macOS the `cea` extra needs a Fortran compiler; see the
-[README](https://github.com/felipebogaertsm/machwave#macos-prerequisite-for-the-cea-extra-gfortran)
-for the one-time setup.
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 </p>
 
 Machwave is an open source Python library for chemical rocket propulsion simulation.
-Here is what it is capable of:
+Machwave's main capabilities are:
 
 - **Propellant modeling** with pre-defined formulations, and NASA CEA integration
   for composition-derived thermochemistry (`cea` extra)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,14 +7,14 @@ Machwave is an open source Python library for chemical rocket propulsion simulat
 Machwave's main capabilities are:
 
 - **Propellant modeling** with pre-defined formulations, and NASA CEA integration
-  for composition-derived thermochemistry (`cea` extra)
-- **Grain regression analysis** with FMM for 2D and 3D geometries (`fmm` extra)
-- **Rocket motor and engine simulation** for the following categories:
+  for composition-derived thermochemistry
+- **Grain regression analysis** with the fast marching method for 2D and 3D geometries
+- **Motor/engine simulation** for the following categories:
     - Solid Rocket Motors
-    - *Bi-propellant Liquid Rocket Engines (in development 🔧)* (`cea` and `liquid` extras)
+    - *Bipropellant Liquid Rocket Engines (in development 🔧)*
     - *Hybrid Rocket Engines (coming soon 🗓️)*
 - **Monte Carlo simulation** for all of the motors/engines above
-- **Integration with RocketPy** for trajectory simulation and analysis (`rocketpy` extra)
+- **Integration with RocketPy** for trajectory simulation and analysis
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,23 +18,16 @@ Machwave's main capabilities are:
 
 ## Installation
 
-Machwave requires **Python 3.11 – 3.14**.
-
 ```bash
 pip install machwave
 ```
 
-The core install depends only on NumPy, SciPy and fluids, and runs a complete solid
-rocket motor simulation with BATES grains, any of the eight bundled solid propellant
-formulations and the full Solid Performance Program 1975 nozzle loss set. Those
-formulations carry pre-computed thermochemical properties, so no thermochemistry
-solver is needed to burn them.
-
-Everything heavier is an optional extra:
+The core install can run a complete solid rocket motor simulation with BATES grains, with any of the preset solid propellant formulations.
+Additional capabilities such as LRE simulation, FMM grain regression, or RocketPy trajectory simulation can be unlocked by installing the extra bundled packages:
 
 | Extra | Unlocks |
 | --- | --- |
-| `cea` | Thermochemistry computed from propellant composition, needed for biliquid engines and for custom solid mixtures |
+| `cea` | Thermochemistry computed from propellant composition, i.e. biliquid engines, custom solid formulations |
 | `liquid` | Propellant tanks and the injector's homogeneous-equilibrium mass flux |
 | `fmm` | Every grain geometry other than BATES, including grains defined by an STL mesh |
 | `plots` | The built-in figures and the Monte Carlo plots |

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,14 +40,10 @@ Install one or several by name, for example:
 pip install machwave[fmm,plots]
 ```
 
-## Quick Start
+## Getting Started
 
 The [Quick Start page](quickstart.md) covers a Solid Rocket Motor simulation.
-Propellant selection, grain geometry, nozzle design, simulation execution and result plotting.
-
-For more complete examples, including coupled trajectory with RocketPy and Monte
-Carlo simulation, check out the
-[examples directory](https://github.com/felipebogaertsm/machwave/tree/main/examples).
+For more complete examples, including coupled trajectory simulation with RocketPy and Monte Carlo, check out the [examples directory](https://github.com/felipebogaertsm/machwave/tree/main/examples).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,14 +22,14 @@ Machwave's main capabilities are:
 pip install machwave
 ```
 
-The core install can run a complete SRM simulation with BATES grains, with any of the preset solid propellant formulations.
-Additional capabilities such as LRE simulation, FMM grain regression, or RocketPy trajectory simulation can be unlocked by installing the extra bundled packages:
+The core install can run a complete solid rocket motor simulation with BATES grains, using any of the preset solid propellant formulations.
+Additional capabilities, such as fast marching method grain regression, liquid feed system modeling or RocketPy trajectory simulation, can be unlocked by installing the optional extras:
 
 | Extra | Unlocks |
 | --- | --- |
-| `cea` | Thermochemistry computed from propellant composition, i.e. biliquid engines, custom solid formulations |
+| `cea` | Thermochemistry computed from propellant composition: every biliquid propellant, and solid formulations defined without pre-computed properties |
 | `liquid` | Fluid state models for propellant tanks and injectors |
-| `fmm` | Fast marching method for complex grain regression analysis |
+| `fmm` | Fast marching method grain regression, for every grain geometry other than BATES, including grains defined by an STL mesh |
 | `plots` | The built-in figures and the Monte Carlo plots |
 | `rocketpy` | The RocketPy adapter for trajectory simulation |
 | `all` | All of the above |

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
   <img src="assets/logo/machwave-lockup-white.svg#only-dark" alt="Machwave" width="400">
 </p>
 
-Machwave is an open source Python library for **internal ballistic simulation** of chemical rocket propulsion systems.
+Machwave is an open source Python library for **internal ballistics simulation** of chemical rocket propulsion systems.
 Machwave's main capabilities are:
 
 - **Propellant modeling** with pre-defined formulations, and NASA CEA integration

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
   <img src="assets/logo/machwave-lockup-white.svg#only-dark" alt="Machwave" width="400">
 </p>
 
-Machwave is an open source Python library for chemical rocket propulsion simulation.
+Machwave is an open source Python library for **internal ballistic simulation** of chemical rocket propulsion systems.
 Machwave's main capabilities are:
 
 - **Propellant modeling** with pre-defined formulations, and NASA CEA integration


### PR DESCRIPTION
Closes #535.

Rewrites the home page installation section around what the core install can do and what each optional extra adds, and corrects a few claims in the extras table:

- The intro said the extras unlock liquid rocket engine simulation, while the capability list above it marks bipropellant liquid rocket engines as still in development. It now names the liquid feed system modeling the extra actually provides.
- `cea` is needed for every biliquid propellant and for solid formulations defined without pre-computed properties. All eight bundled solid formulations carry those properties and evaluate without it.
- `fmm` covers every grain geometry other than BATES, including grains defined by an STL mesh, rather than "complex" ones. `BatesSegment` is the only analytical geometry.
- Solid rocket motor, liquid rocket engine and fast marching method are spelled out, matching the rest of the page.

`mkdocs build --strict` passes.